### PR TITLE
[#3] setting: API 공통 헤더 · 상태코드 · 에러타입 v1 도입

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,4 +35,30 @@ out/
 
 ### VS Code ###
 .vscode/
+/build/
+/target/
+/out/
+/.gradle/
+.gradle-cache/
+/.classpath
+.settings/
+/.idea/
+
+# Local env & secrets
 .env
+.env.*
+!.env.example
+application-local.yml
+application-*.local.yml
+secrets/
+*.keystore
+*.p12
+
+# OS & logs
+.DS_Store
+Thumbs.db
+*.log
+logs/
+*.pid
+hs_err_pid*
+replay_pid*

--- a/src/main/java/com/masterpiece/IPiece/common/exception/ErrorCode.java
+++ b/src/main/java/com/masterpiece/IPiece/common/exception/ErrorCode.java
@@ -1,4 +1,36 @@
 package com.masterpiece.IPiece.common.exception;
 
-public class ErrorCode {
+import lombok.Getter;
+import org.springframework.http.HttpStatus;
+
+@Getter
+public enum ErrorCode {
+
+    /* 공통 - 4xx */
+    VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "입력값이 유효하지 않습니다."),
+    AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "인증이 필요합니다."),
+    PERMISSION_DENIED(HttpStatus.FORBIDDEN, "접근 권한이 없습니다."),
+    NOT_FOUND(HttpStatus.NOT_FOUND, "요청한 리소스를 찾을 수 없습니다."),
+    CONFLICT(HttpStatus.CONFLICT, "요청이 충돌했습니다."),
+    UNPROCESSABLE_ENTITY(HttpStatus.UNPROCESSABLE_ENTITY, "도메인 규칙 위반입니다."),
+    RATE_LIMITED(HttpStatus.TOO_MANY_REQUESTS, "요청이 너무 많습니다."),
+    /* 공통 - 5xx */
+    INTERNAL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "서버 내부 오류가 발생했습니다."),
+    SERVICE_UNAVAILABLE(HttpStatus.SERVICE_UNAVAILABLE, "현재 서비스 이용이 불가합니다."),
+    TIMEOUT(HttpStatus.GATEWAY_TIMEOUT, "요청 처리 시간이 초과되었습니다."),
+
+    /* 거래/주문  4xx */
+    INSUFFICIENT_BALANCE(HttpStatus.UNPROCESSABLE_ENTITY, "잔액이 부족합니다."),
+    MARKET_CLOSED(HttpStatus.UNPROCESSABLE_ENTITY, "현재 거래가 불가능한 시간입니다."),
+    ORDER_NOT_FOUND(HttpStatus.NOT_FOUND, "주문 정보를 찾을 수 없습니다.");
+
+    private final HttpStatus status;
+    private final String message;
+
+    ErrorCode(HttpStatus status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+    public HttpStatus getStatus() { return status; }
+    public String getMessage() { return message; }
 }

--- a/src/main/java/com/masterpiece/IPiece/common/http/Headers.java
+++ b/src/main/java/com/masterpiece/IPiece/common/http/Headers.java
@@ -1,0 +1,100 @@
+package com.masterpiece.IPiece.common.http;
+
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+
+import java.util.Locale;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+
+/**
+ * 공통 헤더 상수/빌더 유틸.
+ * - 서버가 외부 서비스 호출할 때(RestClient/WebClient) 재사용
+ * - 컨트롤러/필터에서도 상수 재사용
+ */
+public final class Headers {
+
+    private Headers() {}
+
+    /** 표준 헤더 키 */
+    public static final class Names {
+        public static final String AUTHORIZATION   = HttpHeaders.AUTHORIZATION;          // "Authorization"
+        public static final String CONTENT_TYPE    = HttpHeaders.CONTENT_TYPE;           // "Content-Type"
+        public static final String ACCEPT          = HttpHeaders.ACCEPT;                 // "Accept"
+        public static final String ACCEPT_LANGUAGE = HttpHeaders.ACCEPT_LANGUAGE;        // "Accept-Language"
+        public static final String CONTENT_LANGUAGE= HttpHeaders.CONTENT_LANGUAGE;       // "Content-Language"
+        public static final String IDEMPOTENCY_KEY = "Idempotency-Key";
+        public static final String X_REQUEST_ID    = "X-Request-Id";
+        private Names() {}
+    }
+
+    /** 값/포맷 */
+    public static final class Values {
+        public static final MediaType JSON = MediaType.APPLICATION_JSON;
+        public static final String BEARER_PREFIX = "Bearer ";
+        private Values() {}
+    }
+
+    /* ===========================
+       빌더(외부 호출시 재사용)
+       =========================== */
+
+    /** 본문 없는 비로그인 요청용 */
+    public static HttpHeaders jsonAcceptOnly() {
+        HttpHeaders h = new HttpHeaders();
+        h.setAccept(java.util.List.of(Values.JSON));
+        return h;
+    }
+
+    /** 본문 있는 비로그인 요청용 */
+    public static HttpHeaders json() {
+        HttpHeaders h = new HttpHeaders();
+        h.setContentType(Values.JSON);
+        h.setAccept(java.util.List.of(Values.JSON));
+        return h;
+    }
+
+    /** 로그인(토큰 포함) 요청용 */
+    public static HttpHeaders jsonWithBearer(String jwt) {
+        HttpHeaders h = json();
+        h.set(Names.AUTHORIZATION, ensureBearer(jwt));
+        return h;
+    }
+
+    /** 멱등성 필요한 거래/공모 참여 요청용 */
+    public static HttpHeaders jsonWithBearerAndIdempotency(String jwt, UUID idempotencyKey) {
+        HttpHeaders h = jsonWithBearer(jwt);
+        h.set(Names.IDEMPOTENCY_KEY, Objects.requireNonNull(idempotencyKey, "idempotencyKey").toString());
+        return h;
+    }
+
+    /** Accept-Language/Content-Language 간단 설정 */
+    public static void setLanguage(HttpHeaders headers, Locale locale) {
+        Optional.ofNullable(headers).ifPresent(h -> {
+            if (locale != null) {
+                h.set(Names.ACCEPT_LANGUAGE, locale.toLanguageTag());
+                h.set(Names.CONTENT_LANGUAGE, locale.toLanguageTag());
+            }
+        });
+    }
+
+    /* ===========================
+       파서/검증 헬퍼
+       =========================== */
+
+    /** "Bearer xxx" 형태 보장 */
+    public static String ensureBearer(String rawToken) {
+        String t = Objects.requireNonNull(rawToken, "jwt");
+        return t.startsWith(Values.BEARER_PREFIX) ? t : Values.BEARER_PREFIX + t;
+    }
+
+    /** Idempotency-Key UUID 여부 검사 (유효하지 않으면 IllegalArgumentException) */
+    public static UUID validateIdempotencyKey(String key) {
+        try {
+            return UUID.fromString(Objects.requireNonNull(key, "Idempotency-Key"));
+        } catch (Exception e) {
+            throw new IllegalArgumentException("Invalid Idempotency-Key (UUID required)");
+        }
+    }
+}

--- a/src/main/java/com/masterpiece/IPiece/common/web/Responses.java
+++ b/src/main/java/com/masterpiece/IPiece/common/web/Responses.java
@@ -1,0 +1,119 @@
+package com.masterpiece.IPiece.common.web;
+
+import org.springframework.http.*;
+import java.net.URI;
+import java.time.Duration;
+import java.util.Map;
+
+/**
+ * HTTP 상태코드 규칙에 맞춘 공통 응답 헬퍼.
+ * - 성공(200/201/202/204)
+ * - 오류(400/401/403/404/409/422/429/500/502/503/504)
+ * - RFC7807 problem+json 간단 빌더 포함
+ */
+public final class Responses {
+    private Responses() {}
+    public static final MediaType PROBLEM_JSON = MediaType.valueOf("application/problem+json");
+
+    /* -------------------- 성공 응답 -------------------- */
+
+    // 200 OK
+    public static <T> ResponseEntity<T> ok(T body) {
+        return ResponseEntity.ok(body);
+    }
+
+    // 201 Created (+ Location 헤더)
+    public static <T> ResponseEntity<T> created(T body) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(body);
+    }
+
+    // 202 Accepted (비동기 접수)
+    public static <T> ResponseEntity<T> accepted(T body) {
+        return ResponseEntity.status(HttpStatus.ACCEPTED).body(body);
+    }
+
+    // 204 No Content
+    public static ResponseEntity<Void> noContent() {
+        return ResponseEntity.noContent().build();
+    }
+
+    /* -------------------- 오류 응답 (problem+json) -------------------- */
+
+    // 400 Bad Request
+    public static ResponseEntity<Map<String, Object>> badRequest(String type, String title, String detail, String instance) {
+        return problem(HttpStatus.BAD_REQUEST, type, title, detail, instance, null);
+    }
+
+    // 401 Unauthorized
+    public static ResponseEntity<Map<String, Object>> unauthorized(String type, String title, String detail, String instance) {
+        return problem(HttpStatus.UNAUTHORIZED, type, title, detail, instance, null);
+    }
+
+    // 403 Forbidden
+    public static ResponseEntity<Map<String, Object>> forbidden(String type, String title, String detail, String instance) {
+        return problem(HttpStatus.FORBIDDEN, type, title, detail, instance, null);
+    }
+
+    // 404 Not Found
+    public static ResponseEntity<Map<String, Object>> notFound(String type, String title, String detail, String instance) {
+        return problem(HttpStatus.NOT_FOUND, type, title, detail, instance, null);
+    }
+
+    // 409 Conflict
+    public static ResponseEntity<Map<String, Object>> conflict(String type, String title, String detail, String instance) {
+        return problem(HttpStatus.CONFLICT, type, title, detail, instance, null);
+    }
+
+    // 422 Unprocessable Entity
+    public static ResponseEntity<Map<String, Object>> unprocessable(String type, String title, String detail, String instance) {
+        return problem(HttpStatus.UNPROCESSABLE_ENTITY, type, title, detail, instance, null);
+    }
+
+    // 429 Too Many Requests (+ Retry-After)
+    public static ResponseEntity<Map<String, Object>> tooManyRequests(String type, String title, String detail, String instance, Duration retryAfter) {
+        HttpHeaders h = new HttpHeaders();
+        if (retryAfter != null) h.set(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfter.toSeconds()));
+        return problem(HttpStatus.TOO_MANY_REQUESTS, type, title, detail, instance, h);
+    }
+
+    // 500 Internal Server Error
+    public static ResponseEntity<Map<String, Object>> internalError(String type, String title, String detail, String instance) {
+        return problem(HttpStatus.INTERNAL_SERVER_ERROR, type, title, detail, instance, null);
+    }
+
+    // 502 Bad Gateway
+    public static ResponseEntity<Map<String, Object>> badGateway(String type, String title, String detail, String instance) {
+        return problem(HttpStatus.BAD_GATEWAY, type, title, detail, instance, null);
+    }
+
+    // 503 Service Unavailable (+ Retry-After)
+    public static ResponseEntity<Map<String, Object>> unavailable(String type, String title, String detail, String instance, Duration retryAfter) {
+        HttpHeaders h = new HttpHeaders();
+        if (retryAfter != null) h.set(HttpHeaders.RETRY_AFTER, String.valueOf(retryAfter.toSeconds()));
+        return problem(HttpStatus.SERVICE_UNAVAILABLE, type, title, detail, instance, h);
+    }
+
+    // 504 Gateway Timeout
+    public static ResponseEntity<Map<String, Object>> gatewayTimeout(String type, String title, String detail, String instance) {
+        return problem(HttpStatus.GATEWAY_TIMEOUT, type, title, detail, instance, null);
+    }
+
+    /* -------------------- 공통 problem 빌더 -------------------- */
+
+    public static ResponseEntity<Map<String, Object>> problem(
+            HttpStatus status,
+            String type, String title, String detail, String instance,
+            HttpHeaders extraHeaders
+    ) {
+        Map<String, Object> body = Map.of(
+                "type", type,
+                "title", title,
+                "status", status.value(),
+                "detail", detail,
+                "instance", instance
+        );
+        HttpHeaders headers = (extraHeaders != null) ? extraHeaders : new HttpHeaders();
+        headers.setContentType(PROBLEM_JSON);
+        return new ResponseEntity<>(body, headers, status);
+    }
+}

--- a/src/main/java/com/masterpiece/IPiece/config/SecurityConfig.java
+++ b/src/main/java/com/masterpiece/IPiece/config/SecurityConfig.java
@@ -1,4 +1,27 @@
 package com.masterpiece.IPiece.config;
 
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
 public class SecurityConfig {
+
+    @Profile("local")
+    @Bean
+    SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.ignoringRequestMatchers("/v1/_debug/**"))
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/v1/_debug/**", "/error").permitAll()
+                        .anyRequest().authenticated()
+                );
+        return http.build();
+    }
+
 }

--- a/src/main/java/com/masterpiece/IPiece/main/api/LocalDebugController.java
+++ b/src/main/java/com/masterpiece/IPiece/main/api/LocalDebugController.java
@@ -34,7 +34,6 @@ public class LocalDebugController {
     @PostMapping("/created")
     public ResponseEntity<Map<String, Object>> created() {
         String id = "demo-123";
-        URI location = URI.create("/v1/_debug/resource/" + id);
         return ResponseEntity
                 .status(HttpStatus.CREATED)
                 .body(Map.of("id", id, "status", "created"));

--- a/src/main/java/com/masterpiece/IPiece/main/api/LocalDebugController.java
+++ b/src/main/java/com/masterpiece/IPiece/main/api/LocalDebugController.java
@@ -1,0 +1,49 @@
+package com.masterpiece.IPiece.main.api;
+
+import com.masterpiece.IPiece.common.exception.ErrorCode;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.net.URI;
+import java.time.Instant;
+import java.util.Map;
+
+@Profile("local")
+@RestController
+@RequestMapping("/v1/_debug")
+public class LocalDebugController {
+
+    // 200 OK + 헤더 에코
+    @GetMapping("/ping")
+    public ResponseEntity<Map<String, Object>> ping(
+            @RequestHeader(value = "Idempotency-Key", required = false) String idem) {
+
+        return ResponseEntity.ok()
+                .header("X-Debug", "on")
+                .header("X-Idem-Echo", idem != null ? idem : "")
+                .body(Map.of(
+                        "ok", true,
+                        "server_time", Instant.now().toString()
+                ));
+    }
+
+    // 201 Created
+    @PostMapping("/created")
+    public ResponseEntity<Map<String, Object>> created() {
+        String id = "demo-123";
+        URI location = URI.create("/v1/_debug/resource/" + id);
+        return ResponseEntity
+                .status(HttpStatus.CREATED)
+                .body(Map.of("id", id, "status", "created"));
+    }
+
+    // 422 Unprocessable
+    @GetMapping("/error")
+    public Map<String, Object> error() {
+        ErrorCode ec = ErrorCode.UNPROCESSABLE_ENTITY;
+        throw new ResponseStatusException(ec.getStatus(), "price는 1 이상이어야 합니다.");
+    }
+}

--- a/src/main/java/com/masterpiece/IPiece/main/api/LocalDebugController.java
+++ b/src/main/java/com/masterpiece/IPiece/main/api/LocalDebugController.java
@@ -7,7 +7,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.server.ResponseStatusException;
 
-import java.net.URI;
 import java.time.Instant;
 import java.util.Map;
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,8 +1,0 @@
-spring.application.name=IPiece
-
-spring.datasource.url=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
-spring.datasource.username=${DB_USER}
-spring.datasource.password=${DB_PASS}
-
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.properties.hibernate.format_sql=true

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,23 @@
+spring:
+  application:
+    name: IPiece
+  profiles:
+    active: local
+
+  datasource:
+    url: jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${DB_USER}
+    password: ${DB_PASS}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    properties:
+      hibernate:
+        format_sql: true
+
+server:
+  error:
+    include-message: always
+    include-stacktrace: never
+    include-binding-errors: never


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
**API 공통 헤더 · 상태코드 · 에러타입 v1 도입**
- ErrorCode
  : 공통 에러 코드·상태·메시지를 한 곳에서 정의해 예외 응답을 표준화
- Header
  : 요청·응답에 공통으로 포함될 헤더(Authorization, Idempotency-Key 등) 규칙 정의
- Responses
  : 응답을 일관된 형태로 반환하기 위한 헬퍼 클래스
- SecurityConfig
  : Spring Security 기본 설정 — 인증·인가 규칙 및 디버그 엔드포인트 허용 설정
- LocalDebugController
  : 로컬 환경에서 응답·헤더·에러 테스트용 임시 API 제공 (ping/created/error)



## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close: #3 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
| request | 명령어 | 결과 | 
| -------- | ----- | ---- |
| GET: <br> /v1/_debug/ping | `curl -i http://localhost:8080/v1/_debug/ping` | <img width="436" height="233" alt="image" src="https://github.com/user-attachments/assets/fd25d2bc-8d13-4caf-8957-c4858b886ba4" /> |
| POST: v1/_debug/created  | `curl -i -X POST http://localhost:8080/v1/_debug/created` | <img width="434" height="202" alt="image" src="https://github.com/user-attachments/assets/993ced85-f899-4f24-b0ca-4d81c336b78c" />|
| GET: /v1/_debug/error | `http://localhost:8080/v1/_debug/error` | <img width="565" height="219" alt="image" src="https://github.com/user-attachments/assets/3aee4475-b66d-4ac9-8f85-04974695073d" />|
