### PR TITLE
[#7]feat:Entity 생성 및 Repository 생성

### DIFF
--- a/src/main/java/com/masterpiece/IPiece/dividends/domain/DividendPayouts.java
+++ b/src/main/java/com/masterpiece/IPiece/dividends/domain/DividendPayouts.java
@@ -1,0 +1,54 @@
+package com.masterpiece.IPiece.dividends.domain;
+
+import com.masterpiece.IPiece.domain.account.VirtualAccount;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "dividend_payouts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class DividendPayouts {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "payout_id")
+    private Long payoutId;
+
+    // 어떤 배당 계획에서 나온 지급인지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "dividend_id", nullable = false)
+    private Dividends dividends;
+
+    // 어떤 계좌(사용자)에게 지급됐는지
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    private VirtualAccount virtualAccount;
+
+    @Column(name = "payout_amount", nullable = false)
+    private Long payoutAmount;
+
+    @Column(name = "payout_status", nullable = false, length = 20)
+    private String payoutStatus; // 예: "PENDING", "COMPLETED", "FAILED"
+
+    @Column(name = "payout_date", nullable = false)
+    private LocalDateTime payoutDate;
+
+    @Column(name = "create_at", nullable = false)
+    private LocalDateTime createAt;
+
+    @Column(name = "update_at")
+    private LocalDateTime updateAt;
+
+    // 양방향 관계 편의 메서드
+    public void setDividends(Dividends dividends) {
+        this.dividends = dividends;
+        if (!dividends.getPayouts().contains(this)) {
+            dividends.getPayouts().add(this);
+        }
+    }
+}

--- a/src/main/java/com/masterpiece/IPiece/dividends/domain/Dividends.java
+++ b/src/main/java/com/masterpiece/IPiece/dividends/domain/Dividends.java
@@ -1,4 +1,55 @@
 package com.masterpiece.IPiece.dividends.domain;
 
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "dividends")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Dividends {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "dividend_id")
+    private Long dividendId;
+
+    /*
+    *******************상품 연결*********************
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id", nullable = false)
+    private Product product;
+    * */
+
+    // 배당 기준일 (언제 보유자 확인할지)
+    @Column(name = "record_date", nullable = false)
+    private LocalDateTime recordDate;
+
+    // 실제 지급일
+    @Column(name = "payout_date", nullable = false)
+    private LocalDateTime payoutDate;
+
+    // 전체 배당 금액
+    @Column(name = "total_amount", nullable = false)
+    private Long totalAmount;
+
+    @Column(name = "create_at", nullable = false)
+    private LocalDateTime createAt;
+
+    @Column(name = "update_at")
+    private LocalDateTime updateAt;
+
+    @OneToMany(mappedBy = "dividends", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<DividendPayouts> payouts = new ArrayList<>();
+
+    // 양방향 편의 메서드
+    public void addPayout(DividendPayouts payout) {
+        payouts.add(payout);
+        payout.setDividends(this);
+    }
 }

--- a/src/main/java/com/masterpiece/IPiece/dividends/infra/DivedendsRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/dividends/infra/DivedendsRepository.java
@@ -1,4 +1,0 @@
-package com.masterpiece.IPiece.dividends.infra;
-
-public class DivedendsRepository {
-}

--- a/src/main/java/com/masterpiece/IPiece/dividends/infra/DividendPayoutsRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/dividends/infra/DividendPayoutsRepository.java
@@ -1,0 +1,11 @@
+package com.masterpiece.IPiece.dividends.infra;
+
+
+import com.masterpiece.IPiece.dividends.domain.DividendPayouts;
+import com.masterpiece.IPiece.domain.account.VirtualAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface DividendPayoutsRepository extends JpaRepository<DividendPayouts, Long> {
+    List<DividendPayouts> findByVirtualAccount(VirtualAccount account);
+}

--- a/src/main/java/com/masterpiece/IPiece/dividends/infra/DividendsRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/dividends/infra/DividendsRepository.java
@@ -1,0 +1,13 @@
+package com.masterpiece.IPiece.dividends.infra;
+
+import com.masterpiece.IPiece.dividends.domain.Dividends;
+import com.masterpiece.IPiece.offering.domain.Product;
+import org.springframework.data.jpa.repository.JpaRepository;
+import java.util.List;
+
+public interface DividendsRepository extends JpaRepository<Dividends, Long> {
+    /*
+    product 연결 후 주석 해제
+    List<Dividends> findByProductId(Long productId);
+     */
+}

--- a/src/main/java/com/masterpiece/IPiece/domain/account/VirtualAccount.java
+++ b/src/main/java/com/masterpiece/IPiece/domain/account/VirtualAccount.java
@@ -1,0 +1,59 @@
+package com.masterpiece.IPiece.domain.account;
+
+
+import com.masterpiece.IPiece.mypage.domain.Holdings;
+import com.masterpiece.IPiece.user.domain.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "virtual_account")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class VirtualAccount {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "account_id")
+    private Long accountId;
+
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    @Column(name = "account_no", nullable = false, unique = true, length = 30)
+    private String accountNo;
+
+    @Column(name = "balance_krw", nullable = false)
+    private Long balanceKrw;
+
+    @Column(name = "wallet_address", nullable = false, unique = true, length = 255)
+    private String walletAddress;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updateAt;
+
+    @Column(name = "create_at", nullable = false)
+    private LocalDateTime createAt;
+
+    @Column(name = "pending_price")
+    private Long pendingPrice;
+
+    @OneToMany(mappedBy = "virtualAccount", fetch = FetchType.LAZY,
+    cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Holdings> holdings = new ArrayList<>();
+
+    public void addHolding(Holdings holding) {
+        holdings.add(holding);
+        holding.setVirtualAccount(this);
+    }
+
+
+
+}

--- a/src/main/java/com/masterpiece/IPiece/domain/infra/VirtualAccountRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/domain/infra/VirtualAccountRepository.java
@@ -1,0 +1,18 @@
+package com.masterpiece.IPiece.domain.infra;
+
+import com.masterpiece.IPiece.domain.account.VirtualAccount;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+public interface VirtualAccountRepository extends JpaRepository<VirtualAccount, Long> {
+
+    // 특정 유저의 가상계좌 조회
+    Optional<VirtualAccount> findByUser_UserId(Long userId);
+
+    // 지갑 주소로 조회
+    Optional<VirtualAccount> findByWalletAddress(String walletAddress);
+
+}

--- a/src/main/java/com/masterpiece/IPiece/mypage/domain/Holdings.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/domain/Holdings.java
@@ -1,4 +1,56 @@
 package com.masterpiece.IPiece.mypage.domain;
 
+
+
+import com.masterpiece.IPiece.domain.account.VirtualAccount;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "holdings")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
 public class Holdings {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "holding_id")
+    private Long holdingId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    private VirtualAccount virtualAccount;
+
+    public void setVirtualAccount(VirtualAccount virtualAccount) {
+        this.virtualAccount = virtualAccount;
+        if (!virtualAccount.getHoldings().contains(this)) {
+            virtualAccount.getHoldings().add(this);
+        }
+    }
+
+    @Column(name = "quantity", nullable = false)
+    private Long quantity;
+
+    @Column(name = "avg_price", nullable = false)
+    private Long avgBuyPrice;
+
+    /*
+    ******************product 연결부분******************
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+    */
+
+    @Column(name = "create_at", nullable = false)
+    private LocalDateTime createAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+
+
 }

--- a/src/main/java/com/masterpiece/IPiece/mypage/domain/Holdings.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/domain/Holdings.java
@@ -21,16 +21,10 @@ public class Holdings {
     @Column(name = "holding_id")
     private Long holdingId;
 
+    @Setter
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "account_id", nullable = false)
     private VirtualAccount virtualAccount;
-
-    public void setVirtualAccount(VirtualAccount virtualAccount) {
-        this.virtualAccount = virtualAccount;
-        if (!virtualAccount.getHoldings().contains(this)) {
-            virtualAccount.getHoldings().add(this);
-        }
-    }
 
     @Column(name = "quantity", nullable = false)
     private Long quantity;

--- a/src/main/java/com/masterpiece/IPiece/mypage/infra/HoldingsRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/infra/HoldingsRepository.java
@@ -1,4 +1,14 @@
 package com.masterpiece.IPiece.mypage.infra;
 
-public class HoldingsRepository {
+import com.masterpiece.IPiece.domain.account.VirtualAccount;
+import com.masterpiece.IPiece.mypage.domain.Holdings;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface HoldingsRepository extends JpaRepository<Holdings, Long> {
+
+    //특정 가상계좌 보유 자산 조회
+    List<Holdings> findAllByVirtualAccount(VirtualAccount virtualAccount);
+
 }

--- a/src/main/java/com/masterpiece/IPiece/user/domain/User.java
+++ b/src/main/java/com/masterpiece/IPiece/user/domain/User.java
@@ -1,4 +1,45 @@
 package com.masterpiece.IPiece.user.domain;
 
+import com.masterpiece.IPiece.domain.account.VirtualAccount;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "users") //DB테이블명 명시(PostgreSQL은 user가 예약어기 때문에 "" 명시)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) //외부 직접 생성 방지
+@AllArgsConstructor
+@Builder
 public class User {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY) //auto_increment
+    @Column(name = "user_id")
+    private Long userId;
+
+    @Column(name = "user_made_id", nullable = false,  unique = true)
+    private String userMadeId;  //사용자 ID
+
+    @Column(name = "password_hash", nullable = false, unique = true)
+    private String passwordHash;    //해시값으로 들어온 비밀번호
+
+    @Column(name = "is_verified", nullable = false)
+    private boolean isVerified; //본인인증 여부
+
+    @Column(name = "join_date", nullable = false)
+    private LocalDateTime joinDate; //가입일
+
+    @Column(name = "create_at", nullable = false)
+    private LocalDateTime createAt; //데이터 생성시간
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt; //마지막 수정시간
+
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    private UserPrivate userPrivate;
+
+    @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)
+    private VirtualAccount virtualAccount;
 }

--- a/src/main/java/com/masterpiece/IPiece/user/domain/User.java
+++ b/src/main/java/com/masterpiece/IPiece/user/domain/User.java
@@ -37,7 +37,7 @@ public class User {
     @Column(name = "updated_at")
     private LocalDateTime updatedAt; //마지막 수정시간
 
-    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL)
+    @OneToOne(mappedBy = "user", cascade = CascadeType.ALL, fetch = FetchType.LAZY)
     private UserPrivate userPrivate;
 
     @OneToOne(mappedBy = "user", fetch = FetchType.LAZY)

--- a/src/main/java/com/masterpiece/IPiece/user/domain/User.java
+++ b/src/main/java/com/masterpiece/IPiece/user/domain/User.java
@@ -22,7 +22,7 @@ public class User {
     @Column(name = "user_made_id", nullable = false,  unique = true)
     private String userMadeId;  //사용자 ID
 
-    @Column(name = "password_hash", nullable = false, unique = true)
+    @Column(name = "password_hash", nullable = false)
     private String passwordHash;    //해시값으로 들어온 비밀번호
 
     @Column(name = "is_verified", nullable = false)

--- a/src/main/java/com/masterpiece/IPiece/user/domain/UserPrivate.java
+++ b/src/main/java/com/masterpiece/IPiece/user/domain/UserPrivate.java
@@ -1,0 +1,46 @@
+package com.masterpiece.IPiece.user.domain;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@Table(name = "user_private")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Entity
+public class UserPrivate {
+
+    @Id
+    @Column(name = "user_id")
+    private Long userId;    //user_id를 PK로 사용
+
+    @OneToOne
+    @MapsId
+    @JoinColumn(name = "user_id")
+    private User user;  //User의 user_id가 FK이다
+
+    @Column(name = "name", nullable = false)
+    private String name;
+
+    @Column(name = "birth_date", nullable = false)
+    private LocalDate birthDate;
+
+    @Column(name = "phone_number", nullable = false)
+    private String phoneNumber;
+
+    @Column(name = "address", nullable = false)
+    private String address;
+
+    @Column(name = "id_card_img", nullable = false)
+    private String idCardImg;
+
+    @Column(name = "create_at", nullable = false)
+    private LocalDateTime createdAt;
+
+    @Column(name = "update_at")
+    private LocalDateTime updateAt;
+}

--- a/src/main/java/com/masterpiece/IPiece/user/infra/UserPrivateRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/user/infra/UserPrivateRepository.java
@@ -1,0 +1,10 @@
+package com.masterpiece.IPiece.user.infra;
+
+import com.masterpiece.IPiece.user.domain.UserPrivate;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserPrivateRepository extends JpaRepository<UserPrivate, Integer> {
+
+}

--- a/src/main/java/com/masterpiece/IPiece/user/infra/UserPrivateRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/user/infra/UserPrivateRepository.java
@@ -5,6 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
-public interface UserPrivateRepository extends JpaRepository<UserPrivate, Integer> {
+public interface UserPrivateRepository extends JpaRepository<UserPrivate, Long> {
 
 }

--- a/src/main/java/com/masterpiece/IPiece/user/infra/UserRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/user/infra/UserRepository.java
@@ -1,4 +1,12 @@
 package com.masterpiece.IPiece.user.infra;
 
-public class UserRepository {
+import com.masterpiece.IPiece.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    //사용자 ID 중복체크용 메서드
+    boolean existsByUserMadeId(String userMadeId);
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,0 @@
-spring.application.name=IPiece
-
-spring.datasource.url=jdbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
-spring.datasource.username=${DB_USER}
-spring.datasource.password=${DB_PASS}
-
-spring.jpa.hibernate.ddl-auto=update
-spring.jpa.properties.hibernate.format_sql=true
-spring.jpa.show-sql=true

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -6,3 +6,4 @@ spring.datasource.password=${DB_PASS}
 
 spring.jpa.hibernate.ddl-auto=update
 spring.jpa.properties.hibernate.format_sql=true
+spring.jpa.show-sql=true


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
Entity 생성  - user, account, holdings, dividends 
Repository 생성 - user, account, holdings, dividends 


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- User / UserPrivate
    - 회원 기본 정보(User), 민감정보(UserPrivate) 분리 설계
    - @OneToOne 양방향 매핑 및 @MapsId로 FK = PK 구조 설정
    - Repository 및 기본 메서드 구현

- VirtualAccount / Holdings
    - 사용자 가상계좌 및 보유자산 관리 도메인 구현
    - User ↔ VirtualAccount (1:1), VirtualAccount ↔ Holdings (1:N) 관계 설정
    - 편의 메서드(addHolding)로 양방향 동기화 처리
    - Repository 및 기본 메서드 구현


- Dividends / DividendPayouts
    - 배당 및 배당 지급 내역 도메인 추가
    - Dividends ↔ DividendPayouts (1:N), VirtualAccount ↔ DividendPayouts (1:N) 관계 설정
    - Repository 및 기본 메서드 구현


- close: #7 


## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 모든 연관관계 기본 fetch 전략을 LAZY 로 설정하여 불필요한 join 방지
- 이후 Product 도메인 연결 시 Holdings 및 Dividends 확장 예정

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->


<img width="1088" height="694" alt="image" src="https://github.com/user-attachments/assets/809ecd6e-cc5a-46a8-a2d1-722ec4a630f2" />
