### PR TITLE
[#32] feat: 거래내역(마이페이지) 조회 기능

### DIFF
--- a/src/main/java/com/masterpiece/IPiece/dividends/infra/DividendPayoutsRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/dividends/infra/DividendPayoutsRepository.java
@@ -5,10 +5,20 @@ import com.masterpiece.IPiece.dividends.domain.DividendPayouts;
 import com.masterpiece.IPiece.common.domain.account.VirtualAccount;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import java.time.LocalDateTime;
+
 
 public interface DividendPayoutsRepository extends JpaRepository<DividendPayouts, Long> {
     List<DividendPayouts> findByDividends_Product_ProductIdAndPayoutStatusOrderByPayoutDateDesc(
             Long productId,
+            String payoutStatus
+    );
+
+    // 특정 계좌에 대해, 기간 내 완료된 배당금 지급 내역 조회 -> mypage에서 거래내역 조회용
+    List<DividendPayouts> findByVirtualAccountAndPayoutDateBetweenAndPayoutStatus(
+            VirtualAccount virtualAccount,
+            LocalDateTime from,
+            LocalDateTime to,
             String payoutStatus
     );
 }

--- a/src/main/java/com/masterpiece/IPiece/market/infra/jpa/TradeExecutionRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/market/infra/jpa/TradeExecutionRepository.java
@@ -14,6 +14,8 @@ import java.util.List;
 
 @Repository
 public interface TradeExecutionRepository extends JpaRepository<TradeExecution, Long> {
+    // 매칭 시간 기준 기간 조회
+    List<TradeExecution> findByMatchTimeBetween(LocalDateTime from, LocalDateTime to);
 
     @Query("""
             SELECT te.product.productId AS productId,

--- a/src/main/java/com/masterpiece/IPiece/market/infra/jpa/TradeExecutionRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/market/infra/jpa/TradeExecutionRepository.java
@@ -1,6 +1,7 @@
 package com.masterpiece.IPiece.market.infra.jpa;
 
 
+import com.masterpiece.IPiece.common.domain.account.VirtualAccount;
 import com.masterpiece.IPiece.market.domain.TradeExecution;
 import com.masterpiece.IPiece.market.infra.jpa.projection.PrevCloseProjection;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -14,8 +15,20 @@ import java.util.List;
 
 @Repository
 public interface TradeExecutionRepository extends JpaRepository<TradeExecution, Long> {
-    // 매칭 시간 기준 기간 조회
-    List<TradeExecution> findByMatchTimeBetween(LocalDateTime from, LocalDateTime to);
+    // 매칭 시간 기준 기간 조회 -> 특정 계좌 기준 체결 내역 조회
+    @Query("""
+        SELECT te
+          FROM TradeExecution te
+          JOIN te.buyOrder  bo
+          JOIN te.sellOrder so
+         WHERE te.matchTime BETWEEN :from AND :to
+           AND (bo.virtualAccount = :account OR so.virtualAccount = :account)
+        """)
+    List<TradeExecution> findByAccountAndMatchTimeBetween(
+            @Param("account") VirtualAccount account,
+            @Param("from") LocalDateTime from,
+            @Param("to") LocalDateTime to
+    );
 
     @Query("""
             SELECT te.product.productId AS productId,

--- a/src/main/java/com/masterpiece/IPiece/mypage/api/MypageController.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/api/MypageController.java
@@ -1,5 +1,6 @@
 package com.masterpiece.IPiece.mypage.api;
 
+import com.masterpiece.IPiece.mypage.api.dto.response.AccountHistoryResponse;
 import com.masterpiece.IPiece.mypage.api.dto.response.FavoriteListResponse;
 import com.masterpiece.IPiece.mypage.api.dto.response.MyhomeResponse;
 import com.masterpiece.IPiece.mypage.application.MypageService;
@@ -42,6 +43,20 @@ public class MypageController {
             @AuthenticationPrincipal Long userId
     ) {
         FavoriteListResponse response = mypageService.getFavorites(userId);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 계좌 거래내역 조회
+     * GET /v1/mypage/account?date_from=2025-09-23&date_to=2025-10-23
+     */
+    @GetMapping("/account")
+    public ResponseEntity<AccountHistoryResponse> getAccountHistory(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam("date_from") String dateFrom,
+            @RequestParam("date_to") String dateTo
+    ) {
+        AccountHistoryResponse response = mypageService.getAccountHistory(userId, dateFrom, dateTo);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/masterpiece/IPiece/mypage/api/dto/AccountHistoryItemDto.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/api/dto/AccountHistoryItemDto.java
@@ -1,0 +1,32 @@
+package com.masterpiece.IPiece.mypage.api.dto;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * /v1/mypage/account 의 history 배열 한 건을 표현하는 DTO
+ */
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class AccountHistoryItemDto {
+
+    @JsonProperty("created_at")
+    private String createdAt;      // "yyyy-MM-dd HH:mm"
+
+    @JsonProperty("type")
+    private String type;           // "구매", "판매", "배당금" 등
+
+    @JsonProperty("description")
+    private String description;    // 예: "다이노탱 토큰 구매"
+
+    @JsonProperty("token_amount")
+    private Long tokenAmount;      // 구매: +수량, 판매: -수량, 배당금/입출금: null
+
+    @JsonProperty("price")
+    private Long price;            // 구매: -현금, 판매: +현금, 배당금: +현금
+}

--- a/src/main/java/com/masterpiece/IPiece/mypage/api/dto/response/AccountHistoryResponse.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/api/dto/response/AccountHistoryResponse.java
@@ -1,0 +1,29 @@
+package com.masterpiece.IPiece.mypage.api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.masterpiece.IPiece.mypage.api.dto.AccountHistoryItemDto;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+    /**
+     * /v1/mypage/account 응답 루트 DTO
+     */
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    @Builder
+    public class AccountHistoryResponse {
+
+        @JsonProperty("total_balance")
+        private Long totalBalance;   // VirtualAccount.balanceKrw
+
+        @JsonProperty("pending_price")
+        private Long pendingPrice;   // VirtualAccount.pendingPrice
+
+        @JsonProperty("history")
+        private List<AccountHistoryItemDto> history;  // 거래내역 (없으면 빈 리스트)
+    }

--- a/src/main/java/com/masterpiece/IPiece/mypage/application/MypageService.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/application/MypageService.java
@@ -6,8 +6,10 @@ import com.masterpiece.IPiece.common.exception.BusinessException;
 import com.masterpiece.IPiece.common.exception.ErrorCode;
 import com.masterpiece.IPiece.favorite.domain.FavoriteList;
 import com.masterpiece.IPiece.favorite.infra.FavoriteListRepository;
+import com.masterpiece.IPiece.mypage.api.dto.AccountHistoryItemDto;
 import com.masterpiece.IPiece.mypage.api.dto.AssetDto;
 import com.masterpiece.IPiece.mypage.api.dto.FavoriteItemDto;
+import com.masterpiece.IPiece.mypage.api.dto.response.AccountHistoryResponse;
 import com.masterpiece.IPiece.mypage.api.dto.response.FavoriteListResponse;
 import com.masterpiece.IPiece.mypage.api.dto.response.MyhomeResponse;
 import com.masterpiece.IPiece.mypage.application.mapper.MypageMapper;
@@ -20,8 +22,14 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 @Service
 @RequiredArgsConstructor
@@ -81,6 +89,52 @@ public class MypageService {
         return FavoriteListResponse.builder()
                 .totalCount(items.size())
                 .items(items)
+                .build();
+    }
+
+    public AccountHistoryResponse getAccountHistory(Long userId, String dateFrom, String dateTo) {
+        // 0. 날짜 파싱
+        LocalDate from = LocalDate.parse(dateFrom);   // 예: "2025-09-23"
+        LocalDate to = LocalDate.parse(dateTo);       // 예: "2025-10-23"
+
+        LocalDateTime fromDateTime = from.atStartOfDay();
+        LocalDateTime toDateTime = to.atTime(LocalTime.MAX);
+
+        // 1. 가상계좌 조회
+        Optional<VirtualAccount> optionalAccount = virtualAccountRepository.findByUser_UserId(userId);
+
+        // 1-1. 가상계좌가 없는 경우: total_balance/pending_price 0, history는 빈 리스트
+        if (optionalAccount.isEmpty()) {
+            return AccountHistoryResponse.builder()
+                    .totalBalance(0L)
+                    .pendingPrice(0L)
+                    .history(List.of())
+                    .build();
+        }
+        VirtualAccount account = optionalAccount.get();
+
+        // 2. 거래내역(구매/판매) 조회 및 매핑
+        List<AccountHistoryItemDto> tradeHistory =
+                mypageMapper.toAccountTradeHistory(account, fromDateTime, toDateTime);
+
+        List<AccountHistoryItemDto> dividendHistory =
+                mypageMapper.toAccountDividendHistory(account, fromDateTime, toDateTime);
+
+        List<AccountHistoryItemDto> history = Stream.concat(
+                        tradeHistory.stream(),
+                        dividendHistory.stream()
+                )
+                .sorted(Comparator.comparing(AccountHistoryItemDto::getCreatedAt).reversed())
+                .collect(Collectors.toList());
+
+        // 4. 합계 값
+        long totalBalance = account.getBalanceKrw();
+        long pendingPrice = account.getPendingPrice() != null ? account.getPendingPrice() : 0L;
+
+        return AccountHistoryResponse.builder()
+                .totalBalance(totalBalance)
+                .pendingPrice(pendingPrice)
+                .history(history)
                 .build();
     }
 }

--- a/src/main/java/com/masterpiece/IPiece/mypage/application/mapper/MypageMapper.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/application/mapper/MypageMapper.java
@@ -232,11 +232,11 @@ public class MypageMapper {
             LocalDateTime to
     ) {
         List<TradeExecution> executions =
-                tradeExecutionRepository.findByMatchTimeBetween(from, to);
+                tradeExecutionRepository.findByAccountAndMatchTimeBetween(account, from, to);
 
         return executions.stream()
                 .map(exec -> mapExecutionToHistoryItem(exec, account))
-                .filter(Objects::nonNull)
+                // DB에서 이미 account 조건을 걸었으므로 null 필터링 불필요
                 .collect(Collectors.toList());
     }
 

--- a/src/main/java/com/masterpiece/IPiece/mypage/application/mapper/MypageMapper.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/application/mapper/MypageMapper.java
@@ -2,6 +2,11 @@ package com.masterpiece.IPiece.mypage.application.mapper;
 
 import com.masterpiece.IPiece.common.domain.account.VirtualAccount;
 import com.masterpiece.IPiece.common.domain.product.Product;
+import com.masterpiece.IPiece.dividends.domain.DividendPayouts;
+import com.masterpiece.IPiece.dividends.infra.DividendPayoutsRepository;
+import com.masterpiece.IPiece.market.domain.TradeExecution;
+import com.masterpiece.IPiece.market.infra.jpa.TradeExecutionRepository;
+import com.masterpiece.IPiece.mypage.api.dto.AccountHistoryItemDto;
 import com.masterpiece.IPiece.mypage.api.dto.AssetDto;
 import com.masterpiece.IPiece.mypage.api.dto.FavoriteItemDto;
 import com.masterpiece.IPiece.mypage.api.dto.PortfolioRatioDto;
@@ -14,8 +19,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
+import java.time.format.DateTimeFormatter;
 import java.time.LocalDateTime;
 import java.util.Optional;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 @Component
@@ -23,6 +30,10 @@ import java.util.stream.Collectors;
 public class MypageMapper {
 
     private final ProductOfferingInfoRepository offeringInfoRepository;
+    private final TradeExecutionRepository tradeExecutionRepository;
+    private final DividendPayoutsRepository dividendPayoutsRepository;
+
+
 
     /**
      * Holdings → AssetDto 변환 (단일)
@@ -210,6 +221,107 @@ public class MypageMapper {
                 .currentPrice(product.getCurrentPrice())
                 .priceChangeRate(priceChangeRate)
                 .isFavorite(true)
+                .build();
+    }
+    /**
+     * 계좌 기준 체결 내역 → 거래내역 DTO 리스트로 변환
+     */
+    public List<AccountHistoryItemDto> toAccountTradeHistory(
+            VirtualAccount account,
+            LocalDateTime from,
+            LocalDateTime to
+    ) {
+        List<TradeExecution> executions =
+                tradeExecutionRepository.findByMatchTimeBetween(from, to);
+
+        return executions.stream()
+                .map(exec -> mapExecutionToHistoryItem(exec, account))
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 계좌 기준 배당금 지급 내역 → 거래내역 DTO 리스트로 변환
+     */
+    public List<AccountHistoryItemDto> toAccountDividendHistory(
+            VirtualAccount account,
+            LocalDateTime from,
+            LocalDateTime to
+    ) {
+        // 완료된 배당만 보여준다고 가정 (status 값은 네가 INSERT한 값에 맞춰서 바꿔도 됨)
+        List<DividendPayouts> payouts =
+                dividendPayoutsRepository.findByVirtualAccountAndPayoutDateBetweenAndPayoutStatus(
+                        account,
+                        from,
+                        to,
+                        "PAID"
+                );
+
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
+
+        return payouts.stream()
+                .map(payout -> {
+                    Product product = payout.getDividends().getProduct();
+
+                    String createdAt = payout.getPayoutDate().format(formatter);
+
+                    String type = "배당금";
+                    String description = product.getProductName() + " 배당금";
+
+                    Long price = payout.getPayoutAmount();   // 배당금은 현금 + (API에서 + 금액)
+
+                    return AccountHistoryItemDto.builder()
+                            .createdAt(createdAt)
+                            .type(type)
+                            .description(description)
+                            .tokenAmount(null)   // 배당은 토큰 수량 변화 없음
+                            .price(price)
+                            .build();
+                })
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * 단일 체결내역 → 이 계좌 기준 history 아이템으로 변환
+     */
+    private AccountHistoryItemDto mapExecutionToHistoryItem(TradeExecution exec, VirtualAccount account) {
+        Product product = exec.getProduct();
+        LocalDateTime time = exec.getMatchTime();
+
+        boolean isBuyAccount = exec.getBuyOrder().getVirtualAccount().equals(account);
+        boolean isSellAccount = exec.getSellOrder().getVirtualAccount().equals(account);
+
+        // 이 계좌와 관련없는 체결이면 무시
+        if (!isBuyAccount && !isSellAccount) {
+            return null;
+        }
+
+        String type;
+        Long tokenAmount = exec.getTradeQuantity();
+        Long tradeAmount = exec.getTradeQuantity() * exec.getTradePrice();
+
+        if (isBuyAccount) {
+            // 구매 : 토큰 +, 현금 -
+            type = "구매";
+            tokenAmount = +tokenAmount;
+            tradeAmount = -tradeAmount;
+        } else {
+            // 판매 : 토큰 -, 현금 +
+            type = "판매";
+            tokenAmount = -tokenAmount;
+            tradeAmount = +tradeAmount;
+        }
+
+        String description = product.getProductName() + " " + type;
+
+        String createdAt = time.format(DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm"));
+
+        return AccountHistoryItemDto.builder()
+                .createdAt(createdAt)
+                .type(type)
+                .description(description)
+                .tokenAmount(tokenAmount)
+                .price(tradeAmount)
                 .build();
     }
 


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
### 마이페이지의 거래내역 화면을 위한 기능 구현
- 특정 기간 동안의 매매 체결 내역과 배당금 지급 내역을 반환
- **입출금 내역은 별도 기능으로 추가 필요**

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
### 1. 폴더 구조
```
src/main/java/com/masterpiece/IPiece
 ├─ common
 │   ├─ domain
 │   │   └─ account
 │   │       └─ VirtualAccount.java
 │   └─ domain/infra
 │       └─ VirtualAccountRepository.java
 │
 ├─ market
 │   ├─ domain
 │   │   └─ TradeExecution.java
 │   └─ infra/jpa
 │       └─ TradeExecutionRepository.java
 │
 ├─ dividends
 │   ├─ domain
 │   │   ├─ Dividends.java
 │   │   └─ DividendPayouts.java
 │   └─ infra
 │       └─ DividendPayoutsRepository.java
 │
 └─ mypage
     ├─ api
     │   ├─ dto
     │   │   ├─ AccountHistoryItemDto.java
     │   │   └─ response
     │   │       └─ AccountHistoryResponse.java
     │   └─ MypageController.java
     ├─ application
     │   ├─ mapper
     │   │   └─ MypageMapper.java
     │   └─ MypageService.java
     └─ domain
         └─ Holdings.java 
```
### 2. 파일별 역할
#### VirtualAccount
- 가상계좌 엔티티
- 사용 필드 : 현재 계좌 잔액(balanceKrw)과 거래 대기 금액(pendingPrice)

#### VirtualAccountRepository
- 거래내역/마이페이지에서 기본 계좌 조회에 사용

#### TradeExecution
- 체결 내역 엔티티
- 사용 필드 : 체결 시간(matchTime), 체결수량(tradeQuantity), 체결가(tradePrice), 매매ID(buyOrder, sellOrder)

#### TradeExecutionRepository
- 특정 기간 내 체결 내역 조회
- Mapper에서 계좌 기준 필터링에 사용

#### DividendPayouts
- 배당금 지급 내역 엔티티
- 사용 필드 : 특정 상품의 배당(dividends), 지급 계좌(virtualAccount), 지급된 배당금(payoutAmount), 지급 상태("PAID"), 지급 시각(payoutDate)

#### DividendPayoutsRepository
- 특정 계좌/기간/상태 기준으로 배당 지급 내역 조회

#### AccountHistoryItemDto
- API 응답의 history 배열 한 항목을 나타내느 DTO

#### AccountHistoryResponse
- API 응답 루트 DTO

#### MypageController
- 마이페이지 관련 API 엔드포인트
- 파라미터(date_from, date_to)를 프론트에서 계산해서 전달

#### MypageService
- 날짜 파싱, 가상계좌 조회, 거래내역(매수/매도), 배당금 내역, history 병합 및 날짜 기준 내림차순 정렬

#### MypageMapper
- 매핑(거래내역, 배당금)

### 3. 주요 기능
#### 3-1. 기간 필터링
- date_from, date_to로 기간을 받아 LocalDateTime으로 반환
- from 00:00:00 ~ to 23:59:59.999... 범위로 조회

#### 3-2. 가상계좌 존재 여부 처리
- 존재하지 않으면 : total_balance =0 , pending_price=0 , history = []
- 존재하면 : trade/dividend 조회

#### 3-3. 매매 내역 생성
- TradeExecution이 기준
- buyOrder.virtualAccount == account면 "구매"
- sellOrder.virtualAccount == account면 "판매"

#### 3-4. 배당금 내역 생성
- DividendPayouts이 기준
- payoutstatus = "PAID"
- type "배당금", description "{상품명} 배당금"

#### 3-5. history 정렬
- created_at 기준 내림차순 정렬

### 4. 요청 예시
```
GET http://localhost:8080/v1/mypage/account?date_from=2025-09-20&date_to=2025-10-30
Authorization: Bearer {accessToken}
```

### 5. 응답 예시
```
{
  "total_balance": 29329,
  "pending_price": 0,
  "history": [
    {
      "created_at": "2025-09-28 09:36",
      "type": "판매",
      "description": "에디 토큰 판매",
      "token_amount": -1,
      "price": 200
    },
    {
      "created_at": "2025-09-27 23:00",
      "type": "배당금",
      "description": "뽀로로 토큰 배당금",
      "token_amount": null,
      "price": 1500
    },
    {
      "created_at": "2025-09-25 23:00",
      "type": "구매",
      "description": "핑크퐁 토큰 구매",
      "token_amount": 2,
      "price": -200
    }
  ]
}
```
- close: #32 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
### 입출금 내역
- API 명세 추가
- DB 테이블 추가
- 백엔드 구현 추가

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
- 테스트 데이터의 경우 가상으로 생성 후 삭제

### 테스트 시나리오
#### 1. 거래내역 조회 대상 사용자 선정 → 이하 사용자 A로 명명
- userId : 12
- accountId : 7

#### 2. 사용자 계좌 정보
- 현금 : 3,800,000원
- 대기금액 : 5000원

#### 3. 가상의 매칭 사용자 선정 → 이하 사용자 B로 명명
- userId : 13
- accountId : 999

#### 4-1. A의 매수 주문 데이터 생성
- 주문 시각 : 2025-09-25 23:00:00
- 상품 : 핑크퐁 토큰
- 주문 내용 : 2개를 각 100원에 매수

#### 4-2. B의 매도 주문 데이터 생성
- 주문 시각 : 2025-09-25 23:00:00
- 상품 : 핑크퐁 토큰
- 주문 내용 : 2개를 각 100원에 매도

#### 4-3. 체결 데이터 생성
- 체결 시각 : 2025-09-25 23:00:00
- 체결 내용 : 핑크퐁 토큰 2개 각 100원

#### 5-1. A의 매도 주문 데이터 생성
- 주문 시각 : 2025-09-28 09:36:00
- 상품 : 에디 토큰
- 주문 내용 : 1개를 200원에 매도

#### 5-2. B의 매수 주문 데이터 생성
- 주문 시각 : 2025-09-28 09:36:00
- 상품 : 에디 토큰
- 주문 내용 : 1개를 200원에 매수

#### 5-3. 체결 데이터 생성
- 체결 시각 : 2025-09-28 09:36:00
- 체결 내용 : 에디 토큰 1개 200원

#### 6-1. 배당 공시 생성
- 상품 : 타요 토큰
- 실제 지급일 : 2025-09-27 12:00:00
- 기준일 : 2025-09-20 00:00:00
- 전체 배당금 : 100,000원

#### 6-2. A가 수령한 배당금
- 지급된 배당금 : 1500원
- 지급일 : 2025-09-27 12:00:00
- 지급 상태 : "PAID"

### 테스트 예상 결과
#### A의 마이페이지 - 거래 내역
- 2025-09-28 09:36:00 : 판매 / 에디 토큰 판매 / -1 , +200
- 2025-09-27 12:00:00 : 배당금 / 타요 토큰 배당금 / +1500
- 2025-09-25 23:00:00 : 구매 / 핑크퐁 토큰 구매 / +2 , -200

### 테스트 결과
- 요청
<img width="1372" alt="image" src="https://github.com/user-attachments/assets/d8812e2a-cd9c-438b-9171-132d8800c77b" />

- 응답
<img width="397" alt="image" src="https://github.com/user-attachments/assets/13d9332a-7103-4c81-9a31-0dde5df2e0fc" />
