### PR TITLE
[#38] feat: 즐겨찾기 렌더용 배치 조회 기능개발

### DIFF
--- a/src/main/java/com/masterpiece/IPiece/favorite/api/FavoriteController.java
+++ b/src/main/java/com/masterpiece/IPiece/favorite/api/FavoriteController.java
@@ -2,10 +2,9 @@ package com.masterpiece.IPiece.favorite.api;
 
 import com.masterpiece.IPiece.common.exception.ErrorCode;
 import com.masterpiece.IPiece.common.web.Responses;
+import com.masterpiece.IPiece.favorite.api.dto.request.FavoriteBatchStatusRequest;
 import com.masterpiece.IPiece.favorite.api.dto.request.FavoriteRegisterRequest;
-import com.masterpiece.IPiece.favorite.api.dto.response.FavoriteAlreadyLikeResponse;
-import com.masterpiece.IPiece.favorite.api.dto.response.FavoriteRegisterResponse;
-import com.masterpiece.IPiece.favorite.api.dto.response.FavoriteUnlikeResponse;
+import com.masterpiece.IPiece.favorite.api.dto.response.*;
 import com.masterpiece.IPiece.favorite.application.FavoriteService;
 import com.masterpiece.IPiece.favorite.application.FavoriteService.FavoriteRegisterResult;
 import com.masterpiece.IPiece.favorite.application.FavoriteService.ProductNotFoundException;
@@ -16,6 +15,8 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
 import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Map;
 
 @RestController
 @RequestMapping("/v1")
@@ -169,6 +170,101 @@ public class FavoriteController {
                     "product_id는 양의 정수여야 합니다.",
                     instanceUri
             );
+        } catch (Exception e) {
+            return Responses.internalError(
+                    "https://ipiece.com/errors/" + ErrorCode.INTERNAL_ERROR.name(),
+                    ErrorCode.INTERNAL_ERROR.name(),
+                    ErrorCode.INTERNAL_ERROR.getMessage(),
+                    instanceUri
+            );
+        }
+    }
+
+    /**
+     * 렌더용 배치 조회
+     *
+     * POST /v1/favorites/status
+     * Body: { "product_ids": ["1","2","3"] }
+     */
+    @PostMapping("/favorites/status")
+    public ResponseEntity<?> getFavoriteStatusBatch(
+            @AuthenticationPrincipal Long userId,
+            @RequestBody FavoriteBatchStatusRequest request
+    ) {
+        String instanceUri = "/v1/favorites/status";
+
+        try {
+            // 1. 인증 여부 확인
+            if (userId == null) {
+                return Responses.unauthorized(
+                        "https://ipiece.com/errors/" + ErrorCode.AUTH_REQUIRED.name(),
+                        ErrorCode.AUTH_REQUIRED.name(),
+                        ErrorCode.AUTH_REQUIRED.getMessage(),
+                        instanceUri
+                );
+            }
+
+            // 2. 기본 검증: null/개수 제한
+            if (request == null || request.isEmpty()) {
+                return Responses.badRequest(
+                        "https://ipiece.com/errors/" + ErrorCode.VALIDATION_ERROR.name(),
+                        ErrorCode.VALIDATION_ERROR.name(),
+                        "product_ids는 최소 1개 이상이어야 합니다.",
+                        instanceUri
+                );
+            }
+
+            int size = request.size();
+            if (size < 1 || size > 100) {
+                return Responses.badRequest(
+                        "https://ipiece.com/errors/" + ErrorCode.VALIDATION_ERROR.name(),
+                        ErrorCode.VALIDATION_ERROR.name(),
+                        "product_ids는 1~100개여야 합니다.",
+                        instanceUri
+                );
+            }
+
+            // 3. 문자열 product_id들을 Long 리스트로 변환
+            List<Long> productIds;
+            try {
+                productIds = request.toProductIdLongList();
+            } catch (NumberFormatException e) {
+                return Responses.badRequest(
+                        "https://ipiece.com/errors/" + ErrorCode.VALIDATION_ERROR.name(),
+                        ErrorCode.VALIDATION_ERROR.name(),
+                        "product_ids 항목은 숫자 문자열이어야 합니다.",
+                        instanceUri
+                );
+            }
+
+            // 4. 서비스 호출
+            List<FavoriteService.FavoriteStatusItem> statusItems =
+                    favoriteService.getFavoriteStatusBatch(userId, productIds);
+
+            // 5. 응답 DTO 변환 (문자열 product_id로 다시 변환)
+            Map<Long, String> originalIdMap = new java.util.HashMap<>();
+            for (String pidStr : request.getProductIds()) {
+                Long pid = Long.parseLong(pidStr);
+                originalIdMap.put(pid, pidStr);
+            }
+
+            List<FavoriteStatusItemResponse> resultItems = statusItems.stream()
+                    .map(item -> FavoriteStatusItemResponse.builder()
+                            .productId(originalIdMap.getOrDefault(item.getProductId(),
+                                    String.valueOf(item.getProductId())))
+                            .liked(item.isLiked())
+                            .favoriteId(item.isLiked()
+                                    ? String.valueOf(item.getFavoriteId())
+                                    : null)
+                            .build())
+                    .toList();
+
+            FavoriteBatchStatusResponse body = FavoriteBatchStatusResponse.builder()
+                    .results(resultItems)
+                    .build();
+
+            return Responses.ok(body);
+
         } catch (Exception e) {
             return Responses.internalError(
                     "https://ipiece.com/errors/" + ErrorCode.INTERNAL_ERROR.name(),

--- a/src/main/java/com/masterpiece/IPiece/favorite/api/dto/request/FavoriteBatchStatusRequest.java
+++ b/src/main/java/com/masterpiece/IPiece/favorite/api/dto/request/FavoriteBatchStatusRequest.java
@@ -1,0 +1,30 @@
+package com.masterpiece.IPiece.favorite.api.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@NoArgsConstructor
+public class FavoriteBatchStatusRequest {
+
+    @JsonProperty("product_ids")
+    private List<String> productIds;   // 예: ["1","2","3"]
+
+    public boolean isEmpty() {
+        return productIds == null || productIds.isEmpty();
+    }
+
+    public int size() {
+        return productIds == null ? 0 : productIds.size();
+    }
+
+    /** 내부 로직에서 사용할 숫자 ID(Long) 리스트로 변환 */
+    public List<Long> toProductIdLongList() {
+        return productIds.stream()
+                .map(Long::parseLong)   // "1" -> 1L
+                .toList();
+    }
+}

--- a/src/main/java/com/masterpiece/IPiece/favorite/api/dto/response/FavoriteBatchStatusResponse.java
+++ b/src/main/java/com/masterpiece/IPiece/favorite/api/dto/response/FavoriteBatchStatusResponse.java
@@ -1,0 +1,15 @@
+package com.masterpiece.IPiece.favorite.api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class FavoriteBatchStatusResponse {
+
+    @JsonProperty("results")
+    private List<FavoriteStatusItemResponse> results;
+}

--- a/src/main/java/com/masterpiece/IPiece/favorite/api/dto/response/FavoriteStatusItemResponse.java
+++ b/src/main/java/com/masterpiece/IPiece/favorite/api/dto/response/FavoriteStatusItemResponse.java
@@ -1,0 +1,22 @@
+package com.masterpiece.IPiece.favorite.api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class FavoriteStatusItemResponse {
+
+    @JsonProperty("product_id")
+    private String productId;
+
+    @JsonProperty("liked")
+    private boolean liked;
+
+    // liked가 false일 땐 null로 내려가도록 설정 (옵션)
+    @JsonProperty("favorite_id")
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    private String favoriteId;
+}

--- a/src/main/java/com/masterpiece/IPiece/favorite/application/FavoriteService.java
+++ b/src/main/java/com/masterpiece/IPiece/favorite/application/FavoriteService.java
@@ -13,6 +13,8 @@ import org.springframework.stereotype.Service;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
+import java.util.Map;
 
 @Service
 @RequiredArgsConstructor
@@ -71,6 +73,49 @@ public class FavoriteService {
         return new FavoriteUnlikeResult(favoriteId, updatedAt);
     }
 
+    /**
+     * 렌더용 배치 조회
+     * - 하나의 유저에 대해 여러 productId에 대한 즐겨찾기 여부를 한 번에 조회
+     */
+    @Transactional
+    public List<FavoriteStatusItem> getFavoriteStatusBatch(Long userId, List<Long> productIds) {
+        if (productIds == null || productIds.isEmpty()) {
+            return List.of();
+        }
+
+        // 1. 해당 유저 + productIds 전체에 대한 즐겨찾기 목록을 한 번에 조회
+        List<FavoriteList> favorites = favoriteListRepository
+                .findByUser_UserIdAndProduct_ProductIdIn(userId, productIds);
+
+        // 2. productId -> FavoriteList 맵 구성
+        Map<Long, FavoriteList> favoriteMap = favorites.stream()
+                .collect(java.util.stream.Collectors.toMap(
+                        fl -> fl.getProduct().getProductId(),
+                        fl -> fl
+                ));
+
+        // 3. 요청된 productIds 순서를 유지하며 결과 리스트 생성
+        return productIds.stream()
+                .distinct() // 동일 productId 중복 요청 방지
+                .map(pid -> {
+                    FavoriteList fl = favoriteMap.get(pid);
+                    if (fl != null) {
+                        return new FavoriteStatusItem(
+                                pid,
+                                true,
+                                fl.getFavoriteId()
+                        );
+                    } else {
+                        return new FavoriteStatusItem(
+                                pid,
+                                false,
+                                null
+                        );
+                    }
+                })
+                .toList();
+    }
+
     /* ===== 서비스 결과 ===== */
 
     @Getter
@@ -105,6 +150,19 @@ public class FavoriteService {
         public FavoriteUnlikeResult(Long favoriteId, OffsetDateTime updatedAt) {
             this.favoriteId = favoriteId;
             this.updatedAt = updatedAt;
+        }
+    }
+
+    @Getter
+    public static class FavoriteStatusItem {
+        private final Long productId;
+        private final boolean liked;
+        private final Long favoriteId; // null if not liked
+
+        public FavoriteStatusItem(Long productId, boolean liked, Long favoriteId) {
+            this.productId = productId;
+            this.liked = liked;
+            this.favoriteId = favoriteId;
         }
     }
 

--- a/src/main/java/com/masterpiece/IPiece/favorite/infra/FavoriteListRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/favorite/infra/FavoriteListRepository.java
@@ -17,6 +17,9 @@ public interface FavoriteListRepository extends JpaRepository<FavoriteList, Long
 
     Optional<FavoriteList> findByUserAndProduct(User user, Product product);
 
+    // 렌더용 배치 조회: 한 유저가 여러 상품을 즐겨찾기한 목록 조회
+    List<FavoriteList> findByUser_UserIdAndProduct_ProductIdIn(Long userId, List<Long> productIds);
+
     // 특정 유저의 찜 목록 조회
     List<FavoriteList> findAllByUser(User user);
 


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 마이페이지 외의 상품 목록 화면에서도 각 상품이 현재 로그인한 사용자의 즐겨찾기에 포함되어 있는지 조회
- 프론트는 화면에 표시되는 상품들의 product_id 배열을 전달하면 서버가 즐겨찾기 여부를 반환

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
### 1. 폴더 구조
```
src/main/java/com/masterpiece/IPiece/favorite
 ├─ api
 │   ├─ FavoriteController.java
 │   └─ dto
 │       ├─ request
 │       │   ├─ FavoriteBatchStatusRequest.java   // 신규: 배치 조회 요청 DTO
 │       │   └─ FavoriteRegisterRequest.java
 │       └─ response
 │           ├─ FavoriteAlreadyLikeResponse.java
 │           ├─ FavoriteBatchStatusResponse.java  // 신규: 배치 조회 응답 DTO
 │           ├─ FavoriteRegisterResponse.java
 │           ├─ FavoriteStatusItemResponse.java   // 신규: 결과 item DTO
 │           └─ FavoriteUnlikeResponse.java
 ├─ application
 │   └─ FavoriteService.java                      // 배치 조회 로직 추가
 ├─ domain
 │   └─ FavoriteList.java
 └─ infra
     └─ FavoriteListRepository.java               // 배치 조회용 메서드 추가
```

### 2. 파일 역할
#### 2-1. FavoriteController
- 바디로 전달된 product_ids 목록에 대해 liked 여부와 favorite_id를 한번에 조회

#### 2-2. FavoriteBatchStatus
- 요청 바디 DTO

#### 2-3. FavoriteStatusItemResponse
- 결과 배열의 한 아이템을 표현하는 응답 DTO

#### 2-4. FavoriteBatchStatusResponse
- 배치 조회 전체 응답 DTO

#### 2-5. FavoriteService
- 여러 상품ID의 즐겨찾기 여부를 한번에 조회
- 상품Id → 즐겨찾기 리스트 맵을 구성한 뒤, 요청된 상품ID 순서를 유지하며 FavoriteStatusItem 리스트 생성

#### 2-6. FavoriteListRepository
- 렌더용 배치 조회를 위해 유저&여러 상품ID에 대한 즐겨찾기 목록을 한 번에 조회

### 3. 주요기능
#### 3-1. 렌더용 배치 즐겨찾기 상태 조회
- 현재 로그인한 유저에 대해, 바디의 상품ID 배열에 들어있는 각 상품별로
- 관심등록 여부(liked)와 favorite_id를 한번에 반환

#### 3-2. 요청 검증 및 에러 처리
- product_ids가 비어 있는 경우 → 400 Bad Request
- product_ids 개수가 1~100 범위를 벗어나는 경우 → 400 Bad Request
- product_ids에 숫자가 아닌 문자열이 들어온 경우 → 400 Bad Request

### 4. 요청 예시
- 엔드포인트
```
POST /v1/favorites/status
Host: localhost:8080
Authorization: Bearer {ACCESS_TOKEN}
Content-Type: application/json; charset=utf-8
```
- 바디
```
{
  "product_ids": ["1", "2", "3"]
}
```

### 5. 응답 예시
```
{
  "results": [
    { "product_id": "1", "liked": true,  "favorite_id": "10" },
    { "product_id": "2", "liked": false },
    { "product_id": "3", "liked": true,  "favorite_id": "11" }
  ]
}
```
- close: #38 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->


## 🔥 Test
<!-- Test -->
### 테스트 시나리오
#### 특정 사용자의 관심목록 데이터
<img width="810" alt="image" src="https://github.com/user-attachments/assets/e20ae399-67bb-44fd-974e-b91716282647" />
- 관심상품ID : 6, 7, 8, 18, 19, 20

#### 렌더용 배치 호출(상품ID 1 ~ 8)
- 예상결과 : 상품ID 6 ~ 8만 favoriteId와 liked = true 반환
- 요청
<img width="593" height="242" alt="image" src="https://github.com/user-attachments/assets/bfc0b23c-77e4-42c1-977d-3d010c15d269" /><br><br>

- 결과
<img width="277"  height="330" alt="image" src="https://github.com/user-attachments/assets/121ce80b-6791-40a8-8872-d15b20bc6625" />
<img width="277" height="300" alt="image" src="https://github.com/user-attachments/assets/41f6e00a-5b84-4820-9ae4-1c74288b54c4" />



- 

