### PR TITLE
[#44] feat: 입출금 거래내역 조회 기능

### DIFF
--- a/src/main/java/com/masterpiece/IPiece/common/domain/account/VirtualAccountJournal.java
+++ b/src/main/java/com/masterpiece/IPiece/common/domain/account/VirtualAccountJournal.java
@@ -1,0 +1,35 @@
+package com.masterpiece.IPiece.common.domain.account;
+
+import com.masterpiece.IPiece.common.domain.BaseEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "virtual_account_journal")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class VirtualAccountJournal extends BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "journal_id")
+    private Long journalId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "account_id", nullable = false)
+    private VirtualAccount virtualAccount;
+
+    @Column(name = "tx_type", nullable = false, length = 20)
+    private String txType;    // 'DEPOSIT(입금)', 'WITHDRAW(출금)', 'TRADE_BUY', 'TRADE_SELL', 'DIVIDEND'
+
+    @Column(name = "amount_krw", nullable = false)
+    private Long amountKrw;   // 입금: +, 출금: -, 매수: -, 매도: +, 배당: +
+
+    @Column(name = "balance_after", nullable = false)
+    private Long balanceAfter; // 이 이벤트 이후 계좌 잔액
+
+    @Column(name = "description", length = 255)
+    private String description;
+}

--- a/src/main/java/com/masterpiece/IPiece/common/domain/infra/VirtualAccountJournalRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/common/domain/infra/VirtualAccountJournalRepository.java
@@ -1,0 +1,15 @@
+package com.masterpiece.IPiece.common.domain.infra;
+
+import com.masterpiece.IPiece.common.domain.account.VirtualAccount;
+import com.masterpiece.IPiece.common.domain.account.VirtualAccountJournal;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface VirtualAccountJournalRepository
+        extends JpaRepository<VirtualAccountJournal, Long> {
+
+    // 해당 계좌의 모든 저널을 created_at 기준 최신순으로 반환
+    List<VirtualAccountJournal> findByVirtualAccountOrderByCreateAtDesc(
+            VirtualAccount account
+    );
+}

--- a/src/main/java/com/masterpiece/IPiece/mypage/api/MypageController.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/api/MypageController.java
@@ -1,6 +1,7 @@
 package com.masterpiece.IPiece.mypage.api;
 
 import com.masterpiece.IPiece.mypage.api.dto.response.AccountHistoryResponse;
+import com.masterpiece.IPiece.mypage.api.dto.response.AccountJournalResponse;
 import com.masterpiece.IPiece.mypage.api.dto.response.FavoriteListResponse;
 import com.masterpiece.IPiece.mypage.api.dto.response.MyhomeResponse;
 import com.masterpiece.IPiece.mypage.application.MypageService;
@@ -57,6 +58,18 @@ public class MypageController {
             @RequestParam("date_to") String dateTo
     ) {
         AccountHistoryResponse response = mypageService.getAccountHistory(userId, dateFrom, dateTo);
+        return ResponseEntity.ok(response);
+    }
+    /**
+     * 가상계좌 분개장(입출금/배당/거래) 내역 조회
+     * 날짜 필터 없이 전체를 최신순으로 반환
+     * GET /v1/mypage/account/journals
+     */
+    @GetMapping("/account/journals")
+    public ResponseEntity<AccountJournalResponse> getAccountJournals(
+            @AuthenticationPrincipal Long userId
+    ) {
+        AccountJournalResponse response = mypageService.getAccountJournals(userId);
         return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/masterpiece/IPiece/mypage/api/dto/AccountJournalItemDto.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/api/dto/AccountJournalItemDto.java
@@ -1,0 +1,17 @@
+package com.masterpiece.IPiece.mypage.api.dto;
+
+import java.time.LocalDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AccountJournalItemDto {
+
+    private Long journalId;
+    private String txType;        // "DEPOSIT", "WITHDRAW", "TRADE_BUY", "TRADE_SELL", "DIVIDEND"
+    private String description;   // "입금 완료", "출금 완료", "배당금 지급" 등
+    private Long amountKrw;       // + / - 포함
+    private Long balanceAfter;    // 이 이벤트 이후 잔액
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/masterpiece/IPiece/mypage/api/dto/response/AccountJournalResponse.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/api/dto/response/AccountJournalResponse.java
@@ -1,0 +1,15 @@
+package com.masterpiece.IPiece.mypage.api.dto.response;
+
+import com.masterpiece.IPiece.mypage.api.dto.AccountJournalItemDto;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AccountJournalResponse {
+
+    private Long totalBalance;                  // 현재 보유 현금 (KRW)
+    private Long pendingPrice;                 // 거래 대기 금액
+    private List<AccountJournalItemDto> items; // 입출금/배당/거래 내역
+}

--- a/src/main/java/com/masterpiece/IPiece/mypage/application/MypageService.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/application/MypageService.java
@@ -1,15 +1,19 @@
 package com.masterpiece.IPiece.mypage.application;
 
 import com.masterpiece.IPiece.common.domain.account.VirtualAccount;
+import com.masterpiece.IPiece.common.domain.account.VirtualAccountJournal;
 import com.masterpiece.IPiece.common.domain.infra.VirtualAccountRepository;
+import com.masterpiece.IPiece.common.domain.infra.VirtualAccountJournalRepository;
 import com.masterpiece.IPiece.common.exception.BusinessException;
 import com.masterpiece.IPiece.common.exception.ErrorCode;
 import com.masterpiece.IPiece.favorite.domain.FavoriteList;
 import com.masterpiece.IPiece.favorite.infra.FavoriteListRepository;
 import com.masterpiece.IPiece.mypage.api.dto.AccountHistoryItemDto;
+import com.masterpiece.IPiece.mypage.api.dto.AccountJournalItemDto;
 import com.masterpiece.IPiece.mypage.api.dto.AssetDto;
 import com.masterpiece.IPiece.mypage.api.dto.FavoriteItemDto;
 import com.masterpiece.IPiece.mypage.api.dto.response.AccountHistoryResponse;
+import com.masterpiece.IPiece.mypage.api.dto.response.AccountJournalResponse;
 import com.masterpiece.IPiece.mypage.api.dto.response.FavoriteListResponse;
 import com.masterpiece.IPiece.mypage.api.dto.response.MyhomeResponse;
 import com.masterpiece.IPiece.mypage.application.mapper.MypageMapper;
@@ -40,6 +44,7 @@ public class MypageService {
     private final HoldingsRepository holdingsRepository;
     private final FavoriteListRepository favoriteListRepository;
     private final MypageMapper mypageMapper;
+    private final VirtualAccountJournalRepository virtualAccountJournalRepository;
 
     private static final int PAGE_SIZE = 10;
 
@@ -135,6 +140,37 @@ public class MypageService {
                 .totalBalance(totalBalance)
                 .pendingPrice(pendingPrice)
                 .history(history)
+                .build();
+    }
+
+    /**
+     * 가상계좌 분개장(입출금/배당/거래) 전체 조회 (날짜 필터 없음, 최신순)
+     */
+    public AccountJournalResponse getAccountJournals(Long userId) {
+
+        // 1. 가상계좌 조회
+        VirtualAccount account = virtualAccountRepository
+                .findByUser_UserId(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.NOT_FOUND));
+
+        // 2. 해당 계좌의 모든 저널을 최신순으로 조회
+        List<VirtualAccountJournal> journals =
+                virtualAccountJournalRepository
+                        .findByVirtualAccountOrderByCreateAtDesc(account);
+
+        // 3. DTO 변환
+        List<AccountJournalItemDto> items = journals.stream()
+                .map(mypageMapper::toAccountJournalItemDto)
+                .collect(Collectors.toList());
+
+        // 4. 상단 요약 정보
+        long totalBalance = account.getBalanceKrw();
+        long pendingPrice = account.getPendingPrice() != null ? account.getPendingPrice() : 0L;
+
+        return AccountJournalResponse.builder()
+                .totalBalance(totalBalance)
+                .pendingPrice(pendingPrice)
+                .items(items)
                 .build();
     }
 }

--- a/src/main/java/com/masterpiece/IPiece/mypage/application/mapper/MypageMapper.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/application/mapper/MypageMapper.java
@@ -1,12 +1,14 @@
 package com.masterpiece.IPiece.mypage.application.mapper;
 
 import com.masterpiece.IPiece.common.domain.account.VirtualAccount;
+import com.masterpiece.IPiece.common.domain.account.VirtualAccountJournal;
 import com.masterpiece.IPiece.common.domain.product.Product;
 import com.masterpiece.IPiece.dividends.domain.DividendPayouts;
 import com.masterpiece.IPiece.dividends.infra.DividendPayoutsRepository;
 import com.masterpiece.IPiece.market.domain.TradeExecution;
 import com.masterpiece.IPiece.market.infra.jpa.TradeExecutionRepository;
 import com.masterpiece.IPiece.mypage.api.dto.AccountHistoryItemDto;
+import com.masterpiece.IPiece.mypage.api.dto.AccountJournalItemDto;
 import com.masterpiece.IPiece.mypage.api.dto.AssetDto;
 import com.masterpiece.IPiece.mypage.api.dto.FavoriteItemDto;
 import com.masterpiece.IPiece.mypage.api.dto.PortfolioRatioDto;
@@ -139,6 +141,22 @@ public class MypageMapper {
                         .ratio((double) entry.getValue() / totalValue * 100)
                         .build())
                 .collect(Collectors.toList());
+    }
+
+    /**
+     * VirtualAccountJournal → AccountJournalItemDto 변환
+     */
+    public AccountJournalItemDto toAccountJournalItemDto(
+            VirtualAccountJournal journal
+    ) {
+        return AccountJournalItemDto.builder()
+                .journalId(journal.getJournalId())
+                .txType(journal.getTxType())
+                .description(journal.getDescription())
+                .amountKrw(journal.getAmountKrw())
+                .balanceAfter(journal.getBalanceAfter())
+                .createdAt(journal.getCreateAt()) // BaseEntity의 createAt
+                .build();
     }
 
     /**


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
### 입출금 거래내역 조회 기능
- 기존 거래 내역 API와 독립된 API

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
### 1. 폴더 구조
```
com.masterpiece.IPiece
 ├─ common
 │   ├─ domain
 │   │   └─ account
 │   │       └─ VirtualAccountJournal.java         // 현금흐름 엔티티
 │   └─ domain
 │       └─ infra
 │           └─ VirtualAccountJournalRepository.java // 현금흐름 JPA 리포지토리
 └─ mypage
     ├─ api
     │   ├─ dto
     │   │   ├─ AccountJournalItemDto.java          // 현금흐름 단일 항목 DTO
     │   │   └─ response
     │   │       └─ AccountJournalResponse.java     // 현금흐름 응답 DTO
     │   └─ MypageController.java                    // /v1/mypage/account/journals 추가
     └─ application
         ├─ mapper
         │   └─ MypageMapper.java                    // VirtualAccountJournal → DTO 매핑 메서드 추가
         └─ MypageService.java                       // getAccountJournals() 서비스 메서드 추가
```
### 2. 주요 기능
#### 가상계좌 현금흐름 조회 API 추가
- 엔드포인트 : GET /v1/mypage/account/journals
- 특정 사용자의 가상계좌 기준으로, 모든 현금흐름을 최신순으로 반환
- 총 보유 KRW와 거래대기 금액을 함께 반환

### 3. 요청 예시
```
GET /v1/mypage/account/journals 
Host: localhost:8080
Authorization: Bearer {accesstoken}
Accept: application/json
```

### 4. 응답 예시
```
{
  "totalBalance": 3370000,
  "pendingPrice": 0,
  "items": [
    {
      "journalId": 5,
      "txType": "DIVIDEND",
      "description": "배당금 지급",
      "amountKrw": 50000,
      "balanceAfter": 3370000,
      "createdAt": "2025-11-17T10:00:00"
    }
]
```
- close: #44 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
- virtual_account_journal에 가상 데이터 삽입
- postman 응답 확인
<img width="478" alt="image" src="https://github.com/user-attachments/assets/79e8cbd7-b295-4bb9-8bb2-bae817e93665" />
<img width="495" height="408" alt="image" src="https://github.com/user-attachments/assets/9c0805d9-c7aa-4c99-bea2-e6f6007a1b03" />
