### PR TITLE
[#65] feat: 공모 상세페이지 API 개발

### DIFF
--- a/src/main/java/com/masterpiece/IPiece/offering/api/OfferingController.java
+++ b/src/main/java/com/masterpiece/IPiece/offering/api/OfferingController.java
@@ -5,6 +5,7 @@ import com.masterpiece.IPiece.common.exception.ErrorCode;
 import com.masterpiece.IPiece.common.util.JwtTokenProvider;
 import com.masterpiece.IPiece.common.web.Responses;
 import com.masterpiece.IPiece.offering.api.dto.response.OfferingListResponse;
+import com.masterpiece.IPiece.offering.api.dto.response.OfferingProductDetailResponse;
 import com.masterpiece.IPiece.offering.api.dto.response.OfferingProductResponse;
 import com.masterpiece.IPiece.offering.application.OfferingService;
 import com.masterpiece.IPiece.user.infra.UserRepository;
@@ -89,7 +90,7 @@ public class OfferingController {
 
         Long userId = extractUserIdFromToken(request);
 
-        OfferingProductResponse response = offeringService.getOfferingProductDetail(productId, userId);
+        OfferingProductDetailResponse response = offeringService.getOfferingProductDetail(productId, userId);
 
         return Responses.ok(response);
     }

--- a/src/main/java/com/masterpiece/IPiece/offering/api/dto/response/OfferingProductDetailResponse.java
+++ b/src/main/java/com/masterpiece/IPiece/offering/api/dto/response/OfferingProductDetailResponse.java
@@ -1,0 +1,39 @@
+package com.masterpiece.IPiece.offering.api.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.OffsetDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class OfferingProductDetailResponse {
+
+    // Product 테이블 필드
+    private Long productId;           // 상품 ID
+    private String productName;       // 상품명
+    private String owner;             // 발행자
+    private String thumbnailImg;      // 썸네일 이미지 경로
+    private String presentImg;        // 프레젠테이션 이미지
+    private String projectName;       // 프로젝트명
+    private Long issueAmount;         // 발행량
+    private String tokenStandard;     // 토큰 표준 (ERC-20 등)
+    private String exchangeListing;   // 거래소 상장
+    private Long tokenQuantity;       // 토큰 수량
+    private String tokenName;         // 토큰명
+
+    // ProductOfferingInfo 테이블 필드
+    private Integer progressRate;     // 진행률 (0~100)
+    private OffsetDateTime offeringStartDate;  // 공모 시작일
+    private OffsetDateTime offeringEndDate;    // 공모 종료일
+    private Long offeringPrice;       // 공모 가격
+    private String detailImg;         // 상세 이미지
+    private Long offeringAmount;      // 공모 수량
+
+    // FavoriteList (사용자 기준)
+    private Boolean isFavorite;       // 찜 여부 (true/false)
+}

--- a/src/main/java/com/masterpiece/IPiece/offering/application/OfferingService.java
+++ b/src/main/java/com/masterpiece/IPiece/offering/application/OfferingService.java
@@ -7,6 +7,7 @@ import com.masterpiece.IPiece.common.exception.BusinessException;
 import com.masterpiece.IPiece.common.exception.ErrorCode;
 import com.masterpiece.IPiece.market.application.port.FavoriteQueryPort;
 import com.masterpiece.IPiece.offering.api.dto.response.OfferingListResponse;
+import com.masterpiece.IPiece.offering.api.dto.response.OfferingProductDetailResponse;
 import com.masterpiece.IPiece.offering.api.dto.response.OfferingProductResponse;
 import com.masterpiece.IPiece.offering.domain.ProductOfferingInfo;
 import com.masterpiece.IPiece.offering.infra.ProductOfferingInfoRepository;
@@ -124,8 +125,8 @@ public class OfferingService {
     /**
      * 공모 상품 상세 조회 (기존 로직)
      */
-    public OfferingProductResponse getOfferingProductDetail(Long productId, Long userId) {
-        
+    public OfferingProductDetailResponse getOfferingProductDetail(Long productId, Long userId) {
+
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 
@@ -139,8 +140,9 @@ public class OfferingService {
 
         boolean isFavorited = favoriteQueryPort.existsByUserIdAndProductId(userId, productId);
 
-        return convertToOfferingProductResponse(product, offeringInfo, isFavorited);
+        return convertToOfferingProductDetailResponse(product, offeringInfo, isFavorited);
     }
+
 
     /**
      * 커서 기반 상품 조회
@@ -189,4 +191,34 @@ public class OfferingService {
                 .isFavorite(isFavorite)
                 .build();
     }
+
+
+    private OfferingProductDetailResponse convertToOfferingProductDetailResponse(
+            Product product,
+            ProductOfferingInfo offeringInfo,
+            boolean isFavorite
+    ) {
+        return OfferingProductDetailResponse.builder()
+                .productId(product.getProductId())
+                .productName(product.getProductName())
+                .owner(product.getOwner())
+                .thumbnailImg(product.getThumbnailImg())
+                .presentImg(product.getPresentImg())
+                .projectName(product.getProjectName())
+                .issueAmount(product.getIssueAmount())
+                .tokenStandard(product.getTokenStandard())
+                .exchangeListing(product.getExchangeListing())
+                .tokenQuantity(product.getTokenQuantity())
+                .tokenName(product.getTokenName())
+                .progressRate(offeringInfo.getProgressRate())
+                .offeringStartDate(offeringInfo.getOfferingStartDate())
+                .offeringEndDate(offeringInfo.getOfferingEndDate())
+                .offeringPrice(offeringInfo.getOfferingPrice())
+                .detailImg(offeringInfo.getDetailImg())
+                .offeringAmount(offeringInfo.getOfferingAmount())
+                .isFavorite(isFavorite)
+                .build();
+    }
+
+
 }

--- a/src/main/java/com/masterpiece/IPiece/offering/application/OfferingService.java
+++ b/src/main/java/com/masterpiece/IPiece/offering/application/OfferingService.java
@@ -138,8 +138,7 @@ public class OfferingService {
                 .findByProductId(productId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.OFFERING_INFO_NOT_FOUND));
 
-        boolean isFavorited = favoriteQueryPort.existsByUserIdAndProductId(userId, productId);
-
+        boolean isFavorited = userId != null && favoriteQueryPort.existsByUserIdAndProductId(userId, productId);
         return convertToOfferingProductDetailResponse(product, offeringInfo, isFavorited);
     }
 
@@ -179,6 +178,9 @@ public class OfferingService {
             ProductOfferingInfo offeringInfo,
             boolean isFavorite
     ) {
+        if (offeringInfo == null) {
+            throw new BusinessException(ErrorCode.OFFERING_INFO_NOT_FOUND);
+        }
         return OfferingProductResponse.builder()
                 .productId(product.getProductId())
                 .productName(product.getProductName())


### PR DESCRIPTION
## 📌 Summary
공모 상품 상세 조회 API의 Response DTO를 확장하여 Product 및 ProductOfferingInfo 테이블의 추가 정보를 반환하도록 개선했습니다.

## ✍️ Description
- **OfferingProductDetailResponse** 새로 생성
- Product 테이블의 추가 필드: presentImg, projectName, issueAmount, tokenStandard, exchangeListing, tokenQuantity, tokenName
- ProductOfferingInfo 테이블의 추가 필드: detailImg, offeringAmount
- `convertToOfferingProductDetailResponse()` 메서드로 두 엔티티의 데이터를 하나의 Response DTO로 변환

## 💡 PR Point
리스트 조회와 상세 조회의 데이터 요구사항이 다르기 때문에 DTO를 분리함으로써:
- **네트워크 효율성**: 리스트에서 불필요한 상세 정보 제외
- **응답 시간**: 리스트 조회의 응답 크기 최소화
- **명확성**: DTO 이름으로 사용 목적 명확히 표현
- close: #65 

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
<img width="1087" height="845" alt="image" src="https://github.com/user-attachments/assets/6b6193dd-6fa6-4518-a341-a157dc6dff8f" />
