### PR TITLE
[#61] feat: 호가 매칭 엔진 및 호가 조회 API 개발

### DIFF
--- a/src/main/java/com/masterpiece/IPiece/config/SecurityConfig.java
+++ b/src/main/java/com/masterpiece/IPiece/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                                 "/v1/market/products",
                                 "/v1/market/*/details",
                                 "/v1/market/*/chart",
-                                "/v1/market/*/orderbook",
+                                "/v1/market/*/orders",
                                 "/v1/market/*/detail",
                                 "/v1/main/home",
                                 "/v1/offerings",

--- a/src/main/java/com/masterpiece/IPiece/market/api/MarketController.java
+++ b/src/main/java/com/masterpiece/IPiece/market/api/MarketController.java
@@ -111,4 +111,11 @@ public class MarketController {
         var response = marketService.getHoldingAsset(userId, productId);
         return ResponseEntity.ok(response);
     }
+
+    @GetMapping("/{product_id}/orders")
+    public ResponseEntity<OrderBookResponse> getOrderBook(
+            @PathVariable("product_id") Long productId
+    ) {
+        return ResponseEntity.ok(marketService.getOrderBook(productId));
+    }
 }

--- a/src/main/java/com/masterpiece/IPiece/market/api/dto/response/OrderBookResponse.java
+++ b/src/main/java/com/masterpiece/IPiece/market/api/dto/response/OrderBookResponse.java
@@ -1,0 +1,41 @@
+package com.masterpiece.IPiece.market.api.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+@AllArgsConstructor
+public class OrderBookResponse {
+
+    private Summary summary;
+    private List<OrderBookItem> orders_sell;
+    private List<OrderBookItem> orders_buy;
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class Summary {
+        private Long highest_price;
+        private Long lowest_price;
+        private Long last_price;
+        private double price_change;
+        private Long limit_up_price;
+        private Long limit_down_price;
+        private Long this_week_volume;
+        private Long last_week_volume;
+    }
+
+    @Getter
+    @AllArgsConstructor
+    @Builder
+    public static class OrderBookItem {
+        private Long order_price;
+        private Long quantity;
+        private double price_change;
+    }
+}
+

--- a/src/main/java/com/masterpiece/IPiece/market/application/MarketService.java
+++ b/src/main/java/com/masterpiece/IPiece/market/application/MarketService.java
@@ -31,6 +31,8 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
@@ -326,7 +328,7 @@ public class MarketService {
             // 동시성으로 unique constraint가 먼저 걸린 경우
             throw new BusinessException(ErrorCode.DUPLICATE_ORDER);
         }
-        orderMatchingService.matchWithRetry(savedOrder);
+        registerAfterCommitMatching(savedOrder.getOrderId());
 
         return OrderResponse.builder()
                 .status_code(200)
@@ -395,7 +397,7 @@ public class MarketService {
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(ErrorCode.DUPLICATE_ORDER);
         }
-        orderMatchingService.matchWithRetry(savedOrder);
+        registerAfterCommitMatching(savedOrder.getOrderId());
 
         return OrderResponse.builder()
                 .status_code(200)
@@ -542,5 +544,36 @@ public class MarketService {
     private double calcChangeRate(long price, long prevClose) {
         if (prevClose == 0) return 0.0;
         return ((double)(price - prevClose) / prevClose) * 100;
+    }
+
+    private void registerAfterCommitMatching(Long orderId) {
+        if (TransactionSynchronizationManager.isSynchronizationActive()) {
+            TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
+                @Override
+                public void suspend() {}
+
+                @Override
+                public void resume() {}
+
+                @Override
+                public void flush() {}
+
+                @Override
+                public void beforeCommit(boolean readOnly) {}
+
+                @Override
+                public void beforeCompletion() {}
+
+                @Override
+                public void afterCommit() {
+                    orderMatchingService.matchWithRetry(orderId);
+                }
+
+                @Override
+                public void afterCompletion(int status) {}
+            });
+        } else {
+            orderMatchingService.matchWithRetry(orderId);
+        }
     }
 }

--- a/src/main/java/com/masterpiece/IPiece/market/application/MarketService.java
+++ b/src/main/java/com/masterpiece/IPiece/market/application/MarketService.java
@@ -66,6 +66,8 @@ public class MarketService {
 
     private final ProductMapper productMapper;
 
+    private final OrderMatchingService orderMatchingService;
+
     public ProductListResponse getProducts(Pageable pageable, Long userId) {
         Page<com.masterpiece.IPiece.common.domain.product.Product> page =
                 productQueryPort.findTradeProducts(pageable);
@@ -317,17 +319,18 @@ public class MarketService {
                 .idempotencyKey(idempotencyKey)
                 .build();
 
-        OrderBook saved;
+        OrderBook savedOrder;
         try {
-            saved = orderBookRepository.save(order);
+            savedOrder = orderBookRepository.save(order);
         } catch (DataIntegrityViolationException e) {
             // 동시성으로 unique constraint가 먼저 걸린 경우
             throw new BusinessException(ErrorCode.DUPLICATE_ORDER);
         }
+        orderMatchingService.match(savedOrder);
 
         return OrderResponse.builder()
                 .status_code(200)
-                .order_id(saved.getOrderId().toString())
+                .order_id(savedOrder.getOrderId().toString())
                 .product_id(productId)
                 .side("BUY")
                 .order_price(price)
@@ -386,16 +389,17 @@ public class MarketService {
                 .idempotencyKey(idempotencyKey)
                 .build();
 
-        OrderBook saved;
+        OrderBook savedOrder;
         try {
-            saved = orderBookRepository.save(order);
+            savedOrder = orderBookRepository.save(order);
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(ErrorCode.DUPLICATE_ORDER);
         }
+        orderMatchingService.match(savedOrder);
 
         return OrderResponse.builder()
                 .status_code(200)
-                .order_id(saved.getOrderId().toString())
+                .order_id(savedOrder.getOrderId().toString())
                 .product_id(productId)
                 .side("SELL")
                 .order_price(price)

--- a/src/main/java/com/masterpiece/IPiece/market/application/MarketService.java
+++ b/src/main/java/com/masterpiece/IPiece/market/application/MarketService.java
@@ -486,4 +486,61 @@ public class MarketService {
                 .total_profit_rate(profitRate)
                 .build();
     }
+
+    public OrderBookResponse getOrderBook(Long productId) {
+
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new IllegalArgumentException("product not found"));
+
+        long currentPrice = product.getCurrentPrice();
+        long prevClose = prevCloseQueryPort.findPrevCloseSingle(productId, ZoneId.of("Asia/Seoul")).orElse(0L);
+
+        double priceChange = (prevClose > 0)
+                ? ((double)(currentPrice - prevClose) / prevClose) * 100
+                : 0.0;
+
+        var now = OffsetDateTime.now();
+        var oneWeekAgo = now.minusDays(7);
+
+        Long highest = tradeExecutionRepository.findHighestPrice(productId, oneWeekAgo, now).orElse(null);
+        Long lowest = tradeExecutionRepository.findLowestPrice(productId, oneWeekAgo, now).orElse(null);
+
+        Long thisWeekVol = tradeExecutionRepository.findVolume(productId, now.minusDays(7), now);
+        Long lastWeekVol = tradeExecutionRepository.findVolume(productId, now.minusDays(14), now.minusDays(7));
+
+        long limitUp = Math.round(prevClose * 1.30);
+        long limitDown = Math.round(prevClose * 0.70);
+
+        var sells = orderBookRepository.findSellOrderLevels(productId);
+        var buys  = orderBookRepository.findBuyOrderLevels(productId);
+
+        var sellItems = sells.stream()
+                .map(s -> new OrderBookResponse.OrderBookItem(s.getPrice(), s.getQty(),
+                        calcChangeRate(s.getPrice(), prevClose)))
+                .toList();
+
+        var buyItems = buys.stream()
+                .map(b -> new OrderBookResponse.OrderBookItem(b.getPrice(), b.getQty(),
+                        calcChangeRate(b.getPrice(), prevClose)))
+                .toList();
+
+        OrderBookResponse.Summary summary =
+                new OrderBookResponse.Summary(
+                        highest,
+                        lowest,
+                        prevClose,
+                        priceChange,
+                        limitUp,
+                        limitDown,
+                        thisWeekVol,
+                        lastWeekVol
+                );
+
+        return new OrderBookResponse(summary, sellItems, buyItems);
+    }
+
+    private double calcChangeRate(long price, long prevClose) {
+        if (prevClose == 0) return 0.0;
+        return ((double)(price - prevClose) / prevClose) * 100;
+    }
 }

--- a/src/main/java/com/masterpiece/IPiece/market/application/MarketService.java
+++ b/src/main/java/com/masterpiece/IPiece/market/application/MarketService.java
@@ -326,7 +326,7 @@ public class MarketService {
             // 동시성으로 unique constraint가 먼저 걸린 경우
             throw new BusinessException(ErrorCode.DUPLICATE_ORDER);
         }
-        orderMatchingService.match(savedOrder);
+        orderMatchingService.matchWithRetry(savedOrder);
 
         return OrderResponse.builder()
                 .status_code(200)
@@ -395,7 +395,7 @@ public class MarketService {
         } catch (DataIntegrityViolationException e) {
             throw new BusinessException(ErrorCode.DUPLICATE_ORDER);
         }
-        orderMatchingService.match(savedOrder);
+        orderMatchingService.matchWithRetry(savedOrder);
 
         return OrderResponse.builder()
                 .status_code(200)
@@ -528,12 +528,12 @@ public class MarketService {
                 new OrderBookResponse.Summary(
                         highest,
                         lowest,
-                        prevClose,
+                        currentPrice,
                         priceChange,
                         limitUp,
                         limitDown,
-                        thisWeekVol,
-                        lastWeekVol
+                        thisWeekVol != null ? thisWeekVol : 0L,
+                        lastWeekVol != null ? lastWeekVol : 0L
                 );
 
         return new OrderBookResponse(summary, sellItems, buyItems);

--- a/src/main/java/com/masterpiece/IPiece/market/application/OrderMatchingService.java
+++ b/src/main/java/com/masterpiece/IPiece/market/application/OrderMatchingService.java
@@ -1,0 +1,294 @@
+package com.masterpiece.IPiece.market.application;
+
+import com.masterpiece.IPiece.common.domain.account.VirtualAccount;
+import com.masterpiece.IPiece.common.domain.infra.VirtualAccountRepository;
+import com.masterpiece.IPiece.common.domain.product.Product;
+import com.masterpiece.IPiece.mypage.domain.Holdings;
+import com.masterpiece.IPiece.market.domain.OrderBook;
+import com.masterpiece.IPiece.market.domain.OrderType;
+import com.masterpiece.IPiece.market.domain.TradeExecution;
+import com.masterpiece.IPiece.mypage.infra.HoldingsRepository;
+import com.masterpiece.IPiece.market.infra.jpa.OrderBookRepository;
+import com.masterpiece.IPiece.market.infra.jpa.TradeExecutionRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class OrderMatchingService {
+
+    private final OrderBookRepository orderBookRepository;
+    private final TradeExecutionRepository tradeExecutionRepository;
+    private final VirtualAccountRepository virtualAccountRepository;
+    private final HoldingsRepository holdingsRepository;
+
+    /**
+     * /v1/market/{product_id}/buy, /sell 에서
+     * order_book 에 주문이 저장된 직후 호출되는 진입점
+     */
+    public void match(OrderBook incomingOrder) {
+        if (incomingOrder.getOrderType() == OrderType.BUY) {
+            matchBuyOrder(incomingOrder);
+        } else {
+            matchSellOrder(incomingOrder);
+        }
+    }
+
+    // ==========================
+    // 1) 매수 주문 매칭 (가격/시간 우선, 부분/다중 체결)
+    // ==========================
+    private void matchBuyOrder(OrderBook buyOrder) {
+
+        List<OrderBook> sellOrders = orderBookRepository.findMatchableSellOrders(
+                buyOrder.getProduct().getProductId(),
+                buyOrder.getOrderPrice()
+        );
+
+        long remaining = buyOrder.getRemainQuantity();
+
+        for (OrderBook sellOrder : sellOrders) {
+            if (remaining <= 0) break;
+
+            long available = sellOrder.getRemainQuantity();
+            if (available <= 0) continue;
+
+            long matchQty = Math.min(remaining, available);
+
+            // 호가 방식: 매도자 가격(더 유리한 쪽)으로 체결
+            long tradePrice = sellOrder.getOrderPrice();
+
+            // 체결 저장 + 계좌/보유자산 갱신
+            saveTrade(buyOrder, sellOrder, matchQty, tradePrice);
+
+            // 매도 주문 잔량/상태 갱신
+            long newSellRemain = available - matchQty;
+            sellOrder.setRemainQuantity(newSellRemain);
+            if (newSellRemain == 0) {
+                sellOrder.setPendingStatus(false);
+            }
+
+            remaining -= matchQty;
+        }
+
+        buyOrder.setRemainQuantity(remaining);
+        if (remaining == 0) {
+            buyOrder.setPendingStatus(false);
+        }
+    }
+
+    // ==========================
+    // 2) 매도 주문 매칭 (가격/시간 우선, 부분/다중 체결)
+    // ==========================
+    private void matchSellOrder(OrderBook sellOrder) {
+
+        List<OrderBook> buyOrders = orderBookRepository.findMatchableBuyOrders(
+                sellOrder.getProduct().getProductId(),
+                sellOrder.getOrderPrice()
+        );
+
+        long remaining = sellOrder.getRemainQuantity();
+
+        for (OrderBook buyOrder : buyOrders) {
+            if (remaining <= 0) break;
+
+            long available = buyOrder.getRemainQuantity();
+            if (available <= 0) continue;
+
+            long matchQty = Math.min(remaining, available);
+
+            // 호가 방식: 매수자 가격(더 유리한 쪽)으로 체결
+            long tradePrice = buyOrder.getOrderPrice();
+
+            saveTrade(buyOrder, sellOrder, matchQty, tradePrice);
+
+            long newBuyRemain = available - matchQty;
+            buyOrder.setRemainQuantity(newBuyRemain);
+            if (newBuyRemain == 0) {
+                buyOrder.setPendingStatus(false);
+            }
+
+            remaining -= matchQty;
+        }
+
+        sellOrder.setRemainQuantity(remaining);
+        if (remaining == 0) {
+            sellOrder.setPendingStatus(false);
+        }
+    }
+
+    // ==========================
+    // 3) 체결 기록 저장 (trade_execution)
+    // ==========================
+    private void saveTrade(OrderBook buyOrder,
+                           OrderBook sellOrder,
+                           long qty,
+                           long price) {
+
+        TradeExecution trade = TradeExecution.builder()
+                .product(buyOrder.getProduct())
+                .buyOrder(buyOrder)
+                .sellOrder(sellOrder)
+                .tradeQuantity(qty)
+                .tradePrice(price)
+                .matchTime(OffsetDateTime.now())
+                .settleTime(OffsetDateTime.now())
+                .tradeState(true)
+                .build();
+
+        tradeExecutionRepository.save(trade);
+
+        // 체결을 기준으로 virtual_account / holdings 업데이트
+        updateAccountsAndHoldings(buyOrder, sellOrder, qty, price);
+    }
+
+    // ==========================
+    // 4) 체결 시점 잔액/보유자산 업데이트
+    //  - 주문 시점에 pending 자금/수량은 이미 잠겨 있다고 전제
+    // ==========================
+    private void updateAccountsAndHoldings(OrderBook buyOrder,
+                                           OrderBook sellOrder,
+                                           long qty,
+                                           long tradePrice) {
+
+        VirtualAccount buyer = buyOrder.getVirtualAccount();
+        VirtualAccount seller = sellOrder.getVirtualAccount();
+        Product product = buyOrder.getProduct();
+
+        long orderPrice = buyOrder.getOrderPrice();
+        long totalTradeAmount = qty * tradePrice;
+
+        // --- (1) 구매자: pending 자금 확정 + 가격 차이 환불 ---
+        // 주문 시점: pending_price += orderPrice * totalQty
+        // 체결 시점: 해당 체결 수량만큼 주문가 기준으로 pending 해제
+        long pendingRelease = orderPrice * qty;
+        buyer.decreasePendingPrice(pendingRelease);
+
+        // 주문가 대비 실제 체결가가 더 낮으면 그 차액을 balance로 환불
+        long refund = (orderPrice - tradePrice) * qty;
+        if (refund > 0) {
+            buyer.increaseBalanceKrw(refund);
+        }
+
+        // 보유자산(매수) 반영: 수량/평단 갱신
+        updateHoldingOnBuy(buyer, product, qty, tradePrice);
+
+        // --- (2) 판매자: 보유자산 감소 + 수익 입금 ---
+        // 판매자 보유 수량 줄이기 (pending_quantity 컬럼이 있다면 거기서 빼는 로직으로 확장 가능)
+        decreaseHoldingOnSell(seller, product, qty);
+
+        // 판매 대금 입금
+        seller.increaseBalanceKrw(totalTradeAmount);
+
+        virtualAccountRepository.save(buyer);
+        virtualAccountRepository.save(seller);
+
+        printTradeLog(buyOrder, sellOrder, qty, tradePrice, refund);
+    }
+
+    // ==========================
+    // 5) 보유자산 업데이트 — BUY (평단 가중 평균)
+    // ==========================
+    private void updateHoldingOnBuy(VirtualAccount buyer,
+                                    Product product,
+                                    long qty,
+                                    long tradePrice) {
+
+        Holdings holding = holdingsRepository.findByVirtualAccountAndProduct(buyer, product)
+                .orElseGet(() -> Holdings.create(buyer, product));
+
+        long oldQty = holding.getQuantity();
+        long oldAvg = holding.getAvgBuyPrice();
+
+        long newQty = oldQty + qty;
+        long newAvg = (oldQty == 0)
+                ? tradePrice
+                : ((oldAvg * oldQty) + (tradePrice * qty)) / newQty;
+
+        holding.setQuantity(newQty);
+        holding.setAvgBuyPrice(newAvg);
+
+        holdingsRepository.save(holding);
+    }
+
+    // ==========================
+    // 6) 보유자산 업데이트 — SELL
+    // ==========================
+    private void decreaseHoldingOnSell(VirtualAccount seller,
+                                       Product product,
+                                       long qty) {
+
+        Holdings holding = holdingsRepository.findByVirtualAccountAndProduct(seller, product)
+                .orElseThrow(() -> new IllegalStateException("보유 수량 부족"));
+
+        long remainQty = holding.getQuantity() - qty;
+        if (remainQty < 0) {
+            throw new IllegalStateException("보유 수량 부족");
+        }
+
+        holding.setQuantity(remainQty);
+        holdingsRepository.save(holding);
+    }
+
+    private void printTradeLog(OrderBook buyOrder,
+                               OrderBook sellOrder,
+                               long qty,
+                               long tradePrice,
+                               long refund) {
+
+        String productName = buyOrder.getProduct().getProductName();
+        Long productId = buyOrder.getProduct().getProductId();
+
+        long buyerRemain = buyOrder.getRemainQuantity();
+        long sellerRemain = sellOrder.getRemainQuantity();
+
+        String buyerType = (buyerRemain == 0) ? "전체체결" : "부분체결";
+        String sellerType = (sellerRemain == 0) ? "전체체결" : "부분체결";
+
+        long totalAmount = qty * tradePrice;
+
+        Long buyerUserId = buyOrder.getVirtualAccount().getUser().getUserId();
+        Long sellerUserId = sellOrder.getVirtualAccount().getUser().getUserId();
+
+        System.out.println();
+        System.out.println("┌───────────────────────────────────────────────┐");
+        System.out.println("│  📈 TRADE EXECUTED                           │");
+        System.out.println("└───────────────────────────────────────────────┘");
+
+        System.out.printf("🧩 상품: %s (%d)%n", productName, productId);
+        System.out.printf("💰 체결가: %,d원%n", tradePrice);
+        System.out.printf("📦 체결 수량: %d개  |  총액: %,d원%n", qty, totalAmount);
+        System.out.println();
+
+        // BUYER 블록
+        System.out.println("👤 [BUYER]");
+        System.out.printf("   • 유저 ID      : %d%n", buyerUserId);
+        System.out.printf("   • 주문 유형    : BUY%n");
+        System.out.printf("   • 체결 수량    : %d개%n", qty);
+        System.out.printf("   • 단가         : %,d원%n", tradePrice);
+        System.out.printf("   • 체결 총액    : %,d원%n", totalAmount);
+        System.out.printf("   • 체결 유형    : %s%n", buyerType);
+        System.out.printf("   • 환불 금액    : %,d원%n", refund);
+        System.out.println();
+
+        // SELLER 블록
+        System.out.println("👤 [SELLER]");
+        System.out.printf("   • 유저 ID      : %d%n", sellerUserId);
+        System.out.printf("   • 주문 유형    : SELL%n");
+        System.out.printf("   • 체결 수량    : %d개%n", qty);
+        System.out.printf("   • 단가         : %,d원%n", tradePrice);
+        System.out.printf("   • 체결 총액    : %,d원%n", totalAmount);
+        System.out.printf("   • 체결 유형    : %s%n", sellerType);
+        System.out.println();
+
+        // 잔량 정보도 같이 찍어주면 디버깅에 도움 됨
+        System.out.println("🔎 [REMAIN]");
+        System.out.printf("   • BUY  remain : %d개%n", buyerRemain);
+        System.out.printf("   • SELL remain : %d개%n", sellerRemain);
+        System.out.println("───────────────────────────────────────────────\n");
+    }
+}

--- a/src/main/java/com/masterpiece/IPiece/market/application/OrderMatchingService.java
+++ b/src/main/java/com/masterpiece/IPiece/market/application/OrderMatchingService.java
@@ -13,7 +13,11 @@ import com.masterpiece.IPiece.market.infra.jpa.TradeExecutionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionDefinition;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 import java.time.OffsetDateTime;
 import java.util.List;
@@ -28,6 +32,7 @@ public class OrderMatchingService {
     private final TradeExecutionRepository tradeExecutionRepository;
     private final VirtualAccountRepository virtualAccountRepository;
     private final HoldingsRepository holdingsRepository;
+    private final PlatformTransactionManager transactionManager;
 
     /**
      * /v1/market/{product_id}/buy, /sell 에서
@@ -43,22 +48,32 @@ public class OrderMatchingService {
 
     /**
      * 낙관적 락 충돌 시 재시도
-     */
-    public void matchWithRetry(OrderBook incomingOrder) {
+    */
+    @Transactional(propagation = Propagation.NOT_SUPPORTED)
+    public void matchWithRetry(Long orderId) {
         int attempts = 0;
-        while (true) {
+        RuntimeException lastError = null;
+        while (attempts < 3) {
             try {
-                match(incomingOrder);
+                executeMatchInNewTransaction(orderId);
                 return;
             } catch (OptimisticLockException | OptimisticLockingFailureException e) {
                 attempts++;
-                if (attempts >= 3) {
-                    throw e;
-                }
-                incomingOrder = orderBookRepository.findById(incomingOrder.getOrderId())
-                        .orElseThrow(() -> e);
+                lastError = e;
             }
         }
+        throw lastError != null ? lastError
+                : new OptimisticLockingFailureException("Failed to match order after retries");
+    }
+
+    private void executeMatchInNewTransaction(Long orderId) {
+        TransactionTemplate template = new TransactionTemplate(transactionManager);
+        template.setPropagationBehavior(TransactionDefinition.PROPAGATION_REQUIRES_NEW);
+        template.executeWithoutResult(status -> {
+            OrderBook incomingOrder = orderBookRepository.findById(orderId)
+                    .orElseThrow(() -> new IllegalArgumentException("Order not found: " + orderId));
+            match(incomingOrder);
+        });
     }
 
     // ==========================
@@ -247,12 +262,12 @@ public class OrderMatchingService {
         Holdings holding = holdingsRepository.findByVirtualAccountAndProduct(seller, product)
                 .orElseThrow(() -> new IllegalStateException("보유 수량 부족"));
 
-        long remainQty = holding.getQuantity() - qty;
-        if (remainQty < 0) {
-            throw new IllegalStateException("보유 수량 부족");
+        long remainPending = holding.getPendingQuantity() - qty;
+        if (remainPending < 0) {
+            throw new IllegalStateException("대기 수량 부족");
         }
 
-        holding.setQuantity(remainQty);
+        holding.setPendingQuantity(remainPending);
         holdingsRepository.save(holding);
     }
 

--- a/src/main/java/com/masterpiece/IPiece/market/application/OrderMatchingService.java
+++ b/src/main/java/com/masterpiece/IPiece/market/application/OrderMatchingService.java
@@ -11,11 +11,13 @@ import com.masterpiece.IPiece.mypage.infra.HoldingsRepository;
 import com.masterpiece.IPiece.market.infra.jpa.OrderBookRepository;
 import com.masterpiece.IPiece.market.infra.jpa.TradeExecutionRepository;
 import lombok.RequiredArgsConstructor;
+import org.springframework.dao.OptimisticLockingFailureException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.OffsetDateTime;
 import java.util.List;
+import jakarta.persistence.OptimisticLockException;
 
 @Service
 @RequiredArgsConstructor
@@ -36,6 +38,26 @@ public class OrderMatchingService {
             matchBuyOrder(incomingOrder);
         } else {
             matchSellOrder(incomingOrder);
+        }
+    }
+
+    /**
+     * 낙관적 락 충돌 시 재시도
+     */
+    public void matchWithRetry(OrderBook incomingOrder) {
+        int attempts = 0;
+        while (true) {
+            try {
+                match(incomingOrder);
+                return;
+            } catch (OptimisticLockException | OptimisticLockingFailureException e) {
+                attempts++;
+                if (attempts >= 3) {
+                    throw e;
+                }
+                incomingOrder = orderBookRepository.findById(incomingOrder.getOrderId())
+                        .orElseThrow(() -> e);
+            }
         }
     }
 

--- a/src/main/java/com/masterpiece/IPiece/market/infra/jpa/OrderBookRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/market/infra/jpa/OrderBookRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
+import java.util.List;
 
 @Repository
 public interface OrderBookRepository extends JpaRepository<OrderBook, Long> {
@@ -29,4 +30,26 @@ public interface OrderBookRepository extends JpaRepository<OrderBook, Long> {
             @Param("productId") Long productId,
             Pageable pageable
     );
+
+    @Query("""
+    SELECT o
+      FROM OrderBook o
+     WHERE o.product.productId = :productId
+       AND o.orderType = com.masterpiece.IPiece.market.domain.OrderType.SELL
+       AND o.pendingStatus = true
+       AND o.orderPrice <= :buyPrice
+     ORDER BY o.orderPrice ASC, o.createdAt ASC
+    """)
+    List<OrderBook> findMatchableSellOrders(Long productId, Long buyPrice);
+
+    @Query("""
+    SELECT o
+      FROM OrderBook o
+     WHERE o.product.productId = :productId
+       AND o.orderType = com.masterpiece.IPiece.market.domain.OrderType.BUY
+       AND o.pendingStatus = true
+       AND o.orderPrice >= :sellPrice
+     ORDER BY o.orderPrice DESC, o.createdAt ASC
+    """)
+    List<OrderBook> findMatchableBuyOrders(Long productId, Long sellPrice);
 }

--- a/src/main/java/com/masterpiece/IPiece/market/infra/jpa/OrderBookRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/market/infra/jpa/OrderBookRepository.java
@@ -41,7 +41,8 @@ public interface OrderBookRepository extends JpaRepository<OrderBook, Long> {
        AND o.orderPrice <= :buyPrice
      ORDER BY o.orderPrice ASC, o.createdAt ASC
     """)
-    List<OrderBook> findMatchableSellOrders(Long productId, Long buyPrice);
+    List<OrderBook> findMatchableSellOrders(@Param("productId") Long productId,
+                                            @Param("buyPrice") Long buyPrice);
 
     @Query("""
     SELECT o
@@ -52,7 +53,8 @@ public interface OrderBookRepository extends JpaRepository<OrderBook, Long> {
        AND o.orderPrice >= :sellPrice
      ORDER BY o.orderPrice DESC, o.createdAt ASC
     """)
-    List<OrderBook> findMatchableBuyOrders(Long productId, Long sellPrice);
+    List<OrderBook> findMatchableBuyOrders(@Param("productId") Long productId,
+                                           @Param("sellPrice") Long sellPrice);
 
     @Query("""
     SELECT o.orderPrice AS price, SUM(o.remainQuantity) AS qty

--- a/src/main/java/com/masterpiece/IPiece/market/infra/jpa/OrderBookRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/market/infra/jpa/OrderBookRepository.java
@@ -1,6 +1,7 @@
 package com.masterpiece.IPiece.market.infra.jpa;
 
 import com.masterpiece.IPiece.market.domain.OrderBook;
+import com.masterpiece.IPiece.market.infra.jpa.projection.OrderBookItemProjection;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.*;
@@ -52,4 +53,26 @@ public interface OrderBookRepository extends JpaRepository<OrderBook, Long> {
      ORDER BY o.orderPrice DESC, o.createdAt ASC
     """)
     List<OrderBook> findMatchableBuyOrders(Long productId, Long sellPrice);
+
+    @Query("""
+    SELECT o.orderPrice AS price, SUM(o.remainQuantity) AS qty
+      FROM OrderBook o
+     WHERE o.product.productId = :productId
+       AND o.orderType = com.masterpiece.IPiece.market.domain.OrderType.SELL
+       AND o.pendingStatus = true
+     GROUP BY o.orderPrice
+     ORDER BY o.orderPrice ASC
+    """)
+    List<OrderBookItemProjection> findSellOrderLevels(@Param("productId") Long productId);
+
+    @Query("""
+    SELECT o.orderPrice AS price, SUM(o.remainQuantity) AS qty
+      FROM OrderBook o
+     WHERE o.product.productId = :productId
+       AND o.orderType = com.masterpiece.IPiece.market.domain.OrderType.BUY
+       AND o.pendingStatus = true
+     GROUP BY o.orderPrice
+     ORDER BY o.orderPrice DESC
+    """)
+    List<OrderBookItemProjection> findBuyOrderLevels(@Param("productId") Long productId);
 }

--- a/src/main/java/com/masterpiece/IPiece/market/infra/jpa/TradeExecutionRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/market/infra/jpa/TradeExecutionRepository.java
@@ -12,6 +12,7 @@ import org.springframework.stereotype.Repository;
 import java.time.OffsetDateTime;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 
 @Repository
 public interface TradeExecutionRepository extends JpaRepository<TradeExecution, Long> {
@@ -84,4 +85,34 @@ public interface TradeExecutionRepository extends JpaRepository<TradeExecution, 
     Long findPrevClosePrice(@Param("productId") Long productId,
                             @Param("startAt") OffsetDateTime startAt,
                             @Param("endAt")   OffsetDateTime endAt);
+
+    @Query("""
+    SELECT MAX(te.tradePrice)
+      FROM TradeExecution te
+     WHERE te.product.productId = :productId
+       AND te.matchTime BETWEEN :from AND :to
+    """)
+    Optional<Long> findHighestPrice(@Param("productId") Long productId,
+                          @Param("from") OffsetDateTime from,
+                          @Param("to") OffsetDateTime to);
+
+    @Query("""
+    SELECT MIN(te.tradePrice)
+      FROM TradeExecution te
+     WHERE te.product.productId = :productId
+       AND te.matchTime BETWEEN :from AND :to
+    """)
+    Optional<Long> findLowestPrice(@Param("productId") Long productId,
+                         @Param("from") OffsetDateTime from,
+                         @Param("to") OffsetDateTime to);
+
+    @Query("""
+    SELECT COALESCE(SUM(te.tradeQuantity), 0)
+      FROM TradeExecution te
+     WHERE te.product.productId = :productId
+       AND te.matchTime BETWEEN :from AND :to
+    """)
+    Long findVolume(@Param("productId") Long productId,
+                    @Param("from") OffsetDateTime from,
+                    @Param("to") OffsetDateTime to);
 }

--- a/src/main/java/com/masterpiece/IPiece/market/infra/jpa/projection/OrderBookItemProjection.java
+++ b/src/main/java/com/masterpiece/IPiece/market/infra/jpa/projection/OrderBookItemProjection.java
@@ -1,0 +1,6 @@
+package com.masterpiece.IPiece.market.infra.jpa.projection;
+
+public interface OrderBookItemProjection {
+    Long getPrice();
+    Long getQty();
+}

--- a/src/main/java/com/masterpiece/IPiece/mypage/domain/Holdings.java
+++ b/src/main/java/com/masterpiece/IPiece/mypage/domain/Holdings.java
@@ -33,20 +33,33 @@ public class Holdings extends BaseEntity {
     @JoinColumn(name = "account_id", nullable = false, referencedColumnName = "account_id")
     private VirtualAccount virtualAccount;
 
+    @Setter
     @Column(name = "quantity", nullable = false)
     @Builder.Default
     private Long quantity = 0L;
 
+    @Setter
     @Column(name = "pending_quantity", nullable = false)
     @Builder.Default
     private Long pendingQuantity = 0L;
 
+    @Setter
     @Column(name = "avg_price", nullable = false)
     private Long avgBuyPrice;
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     @JoinColumn(name = "product_id", referencedColumnName = "product_id", nullable = false)
     private Product product;
+
+    public static Holdings create(VirtualAccount virtualAccount, Product product) {
+        return Holdings.builder()
+                .virtualAccount(virtualAccount)
+                .product(product)
+                .quantity(0L)
+                .pendingQuantity(0L)
+                .avgBuyPrice(0L)
+                .build();
+    }
 
     public void moveToPending(long amount) {
         if (amount <= 0) {
@@ -58,5 +71,4 @@ public class Holdings extends BaseEntity {
         this.quantity -= amount;
         this.pendingQuantity += amount;
     }
-
 }


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
- 2차 거래용 호가 매칭 엔진(Order Matching Engine) 신규 도입
  - 실시간 주문 체결 로직(가격/시간우선, 부분/전체 체결 지원) 구현
  - 체결 결과 기반으로 virtual_account, holdings, trade_execution 자동 갱신
- 상품별 호가 조회 API(/v1/market/{productId}/orders) 구현

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- close: #61 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 매칭 엔진 로직 전체 새로 추가 → 가격/시간 우선 정렬, 부분/전체체결 정확도 개선
- 체결 시점에 VirtualAccount와 Holdings를 일관성 있게 갱신하도록 설계
- 호가 조회 API에서 동일 가격대 수량 병합 및 전일 대비 등락률 계산 기능 포함

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
| 기능 | 결과 |
| ---- | ---- |
| 호가 조회하기<br>`/v1/market/{product_id}/orders`| <img width="500" alt="image" src="https://github.com/user-attachments/assets/544daad2-40f2-4474-aeaf-15901de8c337" />|
| 주문이 들어오면 자동으로 매칭 엔진 구동 후 거래 체결 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/50060918-b2b3-4b6c-a264-afcb2f4ce094" />|
