### PR TITLE
[#98] feat: 배당 관련 관리자 API 개발

### DIFF
--- a/src/main/java/com/masterpiece/IPiece/admin/dividend/api/AdminDividendController.java
+++ b/src/main/java/com/masterpiece/IPiece/admin/dividend/api/AdminDividendController.java
@@ -1,0 +1,97 @@
+package com.masterpiece.IPiece.admin.dividend.api;
+
+import com.masterpiece.IPiece.admin.dividend.api.dto.request.AdminUpsertDividendRequest;
+import com.masterpiece.IPiece.admin.dividend.api.dto.response.AdminDividendListResponse;
+import com.masterpiece.IPiece.admin.dividend.api.dto.response.AdminDividendPayoutsResponse;
+import com.masterpiece.IPiece.admin.dividend.api.dto.response.AdminDividendResponse;
+import com.masterpiece.IPiece.admin.dividend.application.AdminDividendService;
+import com.masterpiece.IPiece.user.domain.User;
+import com.masterpiece.IPiece.user.infra.UserRepository;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+public class AdminDividendController {
+
+    private final AdminDividendService adminDividendService;
+    private final UserRepository userRepository;
+
+    /**
+     * 공통: 관리자 인증 체크 (user_made_id == "admin")
+     */
+    private boolean isAdmin(Authentication authentication) {
+        if (authentication == null || authentication.getName() == null) {
+            return false;
+        }
+
+        Long userId;
+        try {
+            userId = Long.valueOf(authentication.getName());
+        } catch (NumberFormatException e) {
+            return false;
+        }
+
+        User user = userRepository.findById(userId).orElse(null);
+        return user != null && "admin".equals(user.getUserMadeId());
+    }
+
+    /**
+     * 1) 배당 선언 생성/수정
+     * POST /v1/admin/dividends
+     */
+    @PostMapping("/v1/admin/dividends")
+    public ResponseEntity<AdminDividendResponse> upsertDividend(
+            Authentication authentication,
+            @Valid @RequestBody AdminUpsertDividendRequest request
+    ) {
+        if (!isAdmin(authentication)) {
+            // 인증 실패나 관리자 아님 → 403
+            return ResponseEntity.status(403).build();
+        }
+
+        AdminDividendResponse response = adminDividendService.upsertDividend(request);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 2) 배당 선언 목록 조회 (페이징 없음)
+     * GET /v1/admin/dividends?productId=&status=
+     */
+    @GetMapping("/v1/admin/dividends")
+    public ResponseEntity<AdminDividendListResponse> listDividends(
+            Authentication authentication,
+            @RequestParam(value = "productId", required = false) Long productId,
+            @RequestParam(value = "status", required = false) String status
+    ) {
+        if (!isAdmin(authentication)) {
+            return ResponseEntity.status(403).build();
+        }
+
+        AdminDividendListResponse response = adminDividendService.listDividends(productId, status);
+        return ResponseEntity.ok(response);
+    }
+
+    /**
+     * 3) 배당 집행 결과 조회
+     * GET /v1/admin/dividends/{dividendId}/payouts?status=
+     */
+    @GetMapping("/v1/admin/dividends/{dividendId}/payouts")
+    public ResponseEntity<AdminDividendPayoutsResponse> getDividendPayouts(
+            Authentication authentication,
+            @PathVariable Long dividendId,
+            @RequestParam(value = "status", required = false) String status
+    ) {
+        if (!isAdmin(authentication)) {
+            return ResponseEntity.status(403).build();
+        }
+
+        AdminDividendPayoutsResponse response =
+                adminDividendService.getDividendPayouts(dividendId, status);
+
+        return ResponseEntity.ok(response);
+    }
+}

--- a/src/main/java/com/masterpiece/IPiece/admin/dividend/api/dto/request/AdminUpsertDividendRequest.java
+++ b/src/main/java/com/masterpiece/IPiece/admin/dividend/api/dto/request/AdminUpsertDividendRequest.java
@@ -1,0 +1,34 @@
+package com.masterpiece.IPiece.admin.dividend.api.dto.request;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class AdminUpsertDividendRequest {
+
+    @JsonProperty("dividend_id")
+    private Long dividendId;   // 없으면 생성, 있으면 수정
+
+    @NotNull(message = "product_id는 필수입니다.")
+    @JsonProperty("product_id")
+    private Long productId;
+
+    @NotNull(message = "record_date는 필수입니다.")
+    @JsonProperty("record_date")
+    private String recordDate; // "2026-03-15T23:59:59+09:00"
+
+    @NotNull(message = "payout_date는 필수입니다.")
+    @JsonProperty("payout_date")
+    private String payoutDate; // "2026-03-31T10:00:00+09:00"
+
+    @NotNull(message = "total_amount는 필수입니다.")
+    @Min(value = 1, message = "total_amount는 1 이상이어야 합니다.")
+    @JsonProperty("total_amount")
+    private Long totalAmount;
+}

--- a/src/main/java/com/masterpiece/IPiece/admin/dividend/api/dto/response/AdminDividendListResponse.java
+++ b/src/main/java/com/masterpiece/IPiece/admin/dividend/api/dto/response/AdminDividendListResponse.java
@@ -1,0 +1,17 @@
+package com.masterpiece.IPiece.admin.dividend.api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminDividendListResponse {
+
+    @JsonProperty("items")
+    private List<AdminDividendResponse> items;
+
+    @JsonProperty("total_count")
+    private Long totalCount;
+}

--- a/src/main/java/com/masterpiece/IPiece/admin/dividend/api/dto/response/AdminDividendPayoutsResponse.java
+++ b/src/main/java/com/masterpiece/IPiece/admin/dividend/api/dto/response/AdminDividendPayoutsResponse.java
@@ -1,0 +1,47 @@
+package com.masterpiece.IPiece.admin.dividend.api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.time.OffsetDateTime;
+import java.util.List;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminDividendPayoutsResponse {
+
+    @JsonProperty("dividend_id")
+    private Long dividendId;
+
+    @JsonProperty("recipient_count")
+    private Long recipientCount;
+
+    @JsonProperty("total_paid")
+    private Long totalPaid;
+
+    @JsonProperty("failed_count")
+    private Long failedCount;
+
+    @JsonProperty("items")
+    private List<PayoutItem> items;
+
+    @Getter
+    @Builder
+    public static class PayoutItem {
+
+        @JsonProperty("payout_id")
+        private Long payoutId;
+
+        @JsonProperty("account_id")
+        private Long accountId;
+
+        @JsonProperty("payout_amount")
+        private Long payoutAmount;
+
+        @JsonProperty("payout_status")
+        private String payoutStatus; // PAID / FAILED
+
+        @JsonProperty("payout_date")
+        private OffsetDateTime payoutDate;
+    }
+}

--- a/src/main/java/com/masterpiece/IPiece/admin/dividend/api/dto/response/AdminDividendResponse.java
+++ b/src/main/java/com/masterpiece/IPiece/admin/dividend/api/dto/response/AdminDividendResponse.java
@@ -1,0 +1,31 @@
+package com.masterpiece.IPiece.admin.dividend.api.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.List;
+import java.time.OffsetDateTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AdminDividendResponse {
+
+    @JsonProperty("dividend_id")
+    private Long dividendId;
+
+    @JsonProperty("product_id")
+    private Long productId;
+
+    @JsonProperty("status")
+    private String status;
+
+    @JsonProperty("record_date")
+    private OffsetDateTime recordDate;
+
+    @JsonProperty("payout_date")
+    private OffsetDateTime payoutDate;
+
+    @JsonProperty("total_amount")
+    private Long totalAmount;
+
+}

--- a/src/main/java/com/masterpiece/IPiece/admin/dividend/application/AdminDividendService.java
+++ b/src/main/java/com/masterpiece/IPiece/admin/dividend/application/AdminDividendService.java
@@ -1,0 +1,219 @@
+package com.masterpiece.IPiece.admin.dividend.application;
+
+import com.masterpiece.IPiece.admin.dividend.api.dto.request.AdminUpsertDividendRequest;
+import com.masterpiece.IPiece.admin.dividend.api.dto.response.AdminDividendListResponse;
+import com.masterpiece.IPiece.admin.dividend.api.dto.response.AdminDividendPayoutsResponse;
+import com.masterpiece.IPiece.admin.dividend.api.dto.response.AdminDividendPayoutsResponse.PayoutItem;
+import com.masterpiece.IPiece.admin.dividend.api.dto.response.AdminDividendResponse;
+import com.masterpiece.IPiece.common.domain.infra.ProductRepository;
+import com.masterpiece.IPiece.common.domain.product.Product;
+import com.masterpiece.IPiece.common.exception.BusinessException;
+import com.masterpiece.IPiece.common.exception.ErrorCode;
+import com.masterpiece.IPiece.dividends.domain.DividendPayouts;
+import com.masterpiece.IPiece.dividends.domain.DividendStatus;
+import com.masterpiece.IPiece.dividends.domain.Dividends;
+import com.masterpiece.IPiece.dividends.infra.DividendPayoutsRepository;
+import com.masterpiece.IPiece.dividends.infra.DividendsRepository;
+import java.time.OffsetDateTime;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class AdminDividendService {
+
+    private final DividendsRepository dividendsRepository;
+    private final ProductRepository productRepository;
+    private final DividendPayoutsRepository dividendPayoutsRepository;
+
+    // ==========================
+    // 1) 배당 선언 생성/수정
+    // ==========================
+    @Transactional
+    public AdminDividendResponse upsertDividend(AdminUpsertDividendRequest request) {
+        // 1. 날짜 파싱
+        OffsetDateTime recordDate;
+        OffsetDateTime payoutDate;
+        try {
+            recordDate = OffsetDateTime.parse(request.getRecordDate());
+            payoutDate = OffsetDateTime.parse(request.getPayoutDate());
+        } catch (Exception e) {
+            throw new BusinessException(
+                    ErrorCode.VALIDATION_ERROR,
+                    "record_date 또는 payout_date 형식이 올바르지 않습니다."
+            );
+        }
+
+        if (!payoutDate.isAfter(recordDate)) {
+            throw new BusinessException(
+                    ErrorCode.VALIDATION_ERROR,
+                    "payout_date는 record_date 이후여야 합니다."
+            );
+        }
+
+        // 2. 상품 확인
+        Product product = productRepository.findById(request.getProductId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
+
+        Dividends dividends;
+
+        // 3. 생성 vs 수정
+        if (request.getDividendId() == null) {
+            // === 생성 ===
+            dividends = Dividends.builder()
+                    .product(product)
+                    .recordDate(recordDate)
+                    .payoutDate(payoutDate)
+                    .status(DividendStatus.SCHEDULED)
+                    .totalAmount(request.getTotalAmount())
+                    .distributedAmount(0L)
+                    .remainderAmount(0L)
+                    .recipientCount(0)
+                    .build();
+
+            dividendsRepository.save(dividends);
+        } else {
+            // === 수정 ===
+            dividends = dividendsRepository.findById(request.getDividendId())
+                    .orElseThrow(() -> new BusinessException(
+                            ErrorCode.NOT_FOUND,
+                            "배당 정보를 찾을 수 없습니다.")
+                    );
+
+            if (dividends.getStatus() != DividendStatus.SCHEDULED) {
+                throw new BusinessException(
+                        ErrorCode.UNPROCESSABLE_ENTITY,
+                        "SCHEDULED 상태의 배당만 수정할 수 있습니다."
+                );
+            }
+
+            // 필드 업데이트 (id 유지)
+            dividends = Dividends.builder()
+                    .dividendId(dividends.getDividendId())
+                    .product(product)
+                    .recordDate(recordDate)
+                    .payoutDate(payoutDate)
+                    .status(DividendStatus.SCHEDULED)
+                    .totalAmount(request.getTotalAmount())
+                    .distributedAmount(dividends.getDistributedAmount())
+                    .remainderAmount(dividends.getRemainderAmount())
+                    .recipientCount(dividends.getRecipientCount())
+                    .transactionHash(dividends.getTransactionHash())
+                    .blockNumber(dividends.getBlockNumber())
+                    .dividendPayouts(dividends.getDividendPayouts())
+                    .build();
+
+            dividendsRepository.save(dividends);
+        }
+
+        return AdminDividendResponse.builder()
+                .dividendId(dividends.getDividendId())
+                .productId(dividends.getProduct().getProductId())
+                .status(dividends.getStatus().name())
+                .recordDate(dividends.getRecordDate())
+                .payoutDate(dividends.getPayoutDate())
+                .totalAmount(dividends.getTotalAmount())
+                .build();
+    }
+
+    // ==========================
+    // 2) 배당 선언 목록 조회 (페이징 없음)
+    // ==========================
+    @Transactional(readOnly = true)
+    public AdminDividendListResponse listDividends(Long productId, String status) {
+        List<Dividends> list;
+
+        DividendStatus statusEnum = null;
+        if (status != null && !status.isBlank()) {
+            try {
+                statusEnum = DividendStatus.valueOf(status);
+            } catch (IllegalArgumentException e) {
+                throw new BusinessException(
+                        ErrorCode.VALIDATION_ERROR,
+                        "status 값이 올바르지 않습니다."
+                );
+            }
+        }
+
+        if (productId == null && statusEnum == null) {
+            list = dividendsRepository.findAll();
+        } else if (productId != null && statusEnum == null) {
+            list = dividendsRepository.findAllByProduct_ProductId(productId);
+        } else if (productId == null) {
+            list = dividendsRepository.findByStatus(statusEnum);
+        } else {
+            list = dividendsRepository.findByProduct_ProductIdAndStatus(productId, statusEnum);
+        }
+
+        List<AdminDividendResponse> items = list.stream()
+                .map(d -> AdminDividendResponse.builder()
+                        .dividendId(d.getDividendId())
+                        .productId(d.getProduct().getProductId())
+                        .status(d.getStatus().name())
+                        .recordDate(d.getRecordDate())
+                        .payoutDate(d.getPayoutDate())
+                        .totalAmount(d.getTotalAmount())
+                        .build())
+                .toList();
+
+        return AdminDividendListResponse.builder()
+                .items(items)
+                .totalCount((long) items.size())
+                .build();
+    }
+
+    // ==========================
+    // 3) 배당 집행 결과 조회
+    // ==========================
+    @Transactional(readOnly = true)
+    public AdminDividendPayoutsResponse getDividendPayouts(Long dividendId, String status) {
+        // 1. 배당 선언 조회
+        Dividends dividends = dividendsRepository.findById(dividendId)
+                .orElseThrow(() -> new BusinessException(
+                        ErrorCode.NOT_FOUND,
+                        "배당 정보를 찾을 수 없습니다.")
+                );
+
+        // 2. payout 목록 조회
+        List<DividendPayouts> payouts;
+        if (status == null || status.isBlank()) {
+            payouts = dividendPayoutsRepository.findByDividends(dividends);
+        } else {
+            payouts = dividendPayoutsRepository.findByDividendsAndPayoutStatus(dividends, status);
+        }
+
+        // 3. 요약 값 계산
+        long recipientCount = payouts.size();
+
+        long totalPaid = payouts.stream()
+                .filter(p -> "PAID".equalsIgnoreCase(p.getPayoutStatus()))
+                .mapToLong(DividendPayouts::getPayoutAmount)
+                .sum();
+
+        long failedCount = payouts.stream()
+                .filter(p -> "FAILED".equalsIgnoreCase(p.getPayoutStatus()))
+                .count();
+
+        // 4. items 변환
+        List<PayoutItem> items = payouts.stream()
+                .map(p -> PayoutItem.builder()
+                        .payoutId(p.getPayoutId())
+                        .accountId(p.getVirtualAccount().getAccountId())
+                        .payoutAmount(p.getPayoutAmount())
+                        .payoutStatus(p.getPayoutStatus())
+                        .payoutDate(p.getPayoutDate())
+                        .build())
+                .toList();
+
+        // 5. 응답 DTO
+        return AdminDividendPayoutsResponse.builder()
+                .dividendId(dividends.getDividendId())
+                .recipientCount(recipientCount)
+                .totalPaid(totalPaid)
+                .failedCount(failedCount)
+                .items(items)
+                .build();
+    }
+}

--- a/src/main/java/com/masterpiece/IPiece/admin/offeringandtrade/api/dto/AdminProductController.java
+++ b/src/main/java/com/masterpiece/IPiece/admin/offeringandtrade/api/dto/AdminProductController.java
@@ -64,19 +64,39 @@ public class AdminProductController {
 
     /**
      * 공모(OFFERING) 상품에 대해 2차거래(TRADE) 시작 승인
-     *
+     * <p>
      * POST /v1/admin/products/{productId}/enable-offering
      */
     @PostMapping("/v1/admin/products/{productId}/enable-offering")
-    @PreAuthorize("hasRole('ADMIN')") // 실제 권한 이름에 맞게 조정 필요
     @Operation(security = @SecurityRequirement(name = "JWT"))
     public ResponseEntity<AdminEnableSecondaryTradingResponse> enableSecondaryTrading(
-            @AuthenticationPrincipal Long operatorId,                  // JWT에서 온 user_id
+            Authentication authentication,
             @PathVariable("productId") Long productId,
             @Valid @RequestBody AdminEnableSecondaryTradingRequest request
     ) {
+        // 1. 인증 체크 (createProduct와 동일)
+        if (authentication == null || authentication.getName() == null) {
+            return ResponseEntity.status(401).build();
+        }
+
+        // 2. 토큰 subject를 userId로 가정하고 DB에서 유저 조회
+        Long userId;
+        try {
+            userId = Long.valueOf(authentication.getName());
+        } catch (NumberFormatException e) {
+            return ResponseEntity.status(401).build();
+        }
+
+        User user = userRepository.findById(userId).orElse(null);
+
+        if (user == null || !"admin".equals(user.getUserMadeId())) {
+            // 유저가 없거나, user_made_id가 "admin"이 아니면 관리자 아님 → 403
+            return ResponseEntity.status(403).build();
+        }
+
+        // 3. 비즈니스 처리
         AdminEnableSecondaryTradingResponse response =
-                adminProductService.enableSecondaryTrading(productId, operatorId, request);
+                adminProductService.enableSecondaryTrading(productId, request);
 
         return ResponseEntity.ok(response);
     }

--- a/src/main/java/com/masterpiece/IPiece/admin/offeringandtrade/api/dto/response/AdminEnableSecondaryTradingResponse.java
+++ b/src/main/java/com/masterpiece/IPiece/admin/offeringandtrade/api/dto/response/AdminEnableSecondaryTradingResponse.java
@@ -24,6 +24,4 @@ public class AdminEnableSecondaryTradingResponse {
     @JsonProperty("enabled_at")
     private OffsetDateTime enabledAt; // 승인/적용 일시 (ISO-8601)
 
-    @JsonProperty("operator_id")
-    private Long operatorId;          // 처리한 관리자 ID
 }

--- a/src/main/java/com/masterpiece/IPiece/admin/offeringandtrade/application/AdminProductService.java
+++ b/src/main/java/com/masterpiece/IPiece/admin/offeringandtrade/application/AdminProductService.java
@@ -85,7 +85,6 @@ public class AdminProductService {
     @Transactional
     public AdminEnableSecondaryTradingResponse enableSecondaryTrading(
             Long productId,
-            Long operatorId,
             AdminEnableSecondaryTradingRequest request
     ) {
         // 1. confirm 검증
@@ -113,7 +112,6 @@ public class AdminProductService {
                 .previousStatus(previousStatus.name())
                 .newStatus(product.getStatus().name())
                 .enabledAt(enabledAt)
-                .operatorId(operatorId)
                 .build();
     }
 }

--- a/src/main/java/com/masterpiece/IPiece/dividends/infra/DividendPayoutsRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/dividends/infra/DividendPayoutsRepository.java
@@ -1,14 +1,12 @@
 package com.masterpiece.IPiece.dividends.infra;
 
-
+import com.masterpiece.IPiece.dividends.domain.Dividends;
 import com.masterpiece.IPiece.common.domain.account.VirtualAccount;
 import com.masterpiece.IPiece.dividends.domain.DividendPayouts;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.time.OffsetDateTime;
 import java.util.List;
-import java.time.OffsetDateTime;
-
 
 public interface DividendPayoutsRepository extends JpaRepository<DividendPayouts, Long> {
     List<DividendPayouts> findByDividends_Product_ProductIdAndPayoutStatusOrderByPayoutDateDesc(
@@ -23,4 +21,8 @@ public interface DividendPayoutsRepository extends JpaRepository<DividendPayouts
             OffsetDateTime to,
             String payoutStatus
     );
+
+    List<DividendPayouts> findByDividends(Dividends dividends);
+
+    List<DividendPayouts> findByDividendsAndPayoutStatus(Dividends dividends, String payoutStatus);
 }

--- a/src/main/java/com/masterpiece/IPiece/dividends/infra/DividendsRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/dividends/infra/DividendsRepository.java
@@ -1,9 +1,16 @@
 package com.masterpiece.IPiece.dividends.infra;
 
+import com.masterpiece.IPiece.dividends.domain.DividendStatus;
 import com.masterpiece.IPiece.dividends.domain.Dividends;
 import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
+import java.time.OffsetDateTime;
 
 public interface DividendsRepository extends JpaRepository<Dividends, Long> {
     Dividends findByProduct_ProductId(Long productId);
+    List<Dividends> findAllByProduct_ProductId(Long productId); // 251120 타입불일치로 수정(이기현)
+    List<Dividends> findByStatus(DividendStatus status);
+    List<Dividends> findByProduct_ProductIdAndStatus(Long productId, DividendStatus status);
+    List<Dividends> findByStatusAndPayoutDateBefore(DividendStatus status, OffsetDateTime now);
+
 }


### PR DESCRIPTION
배당 생성/수정, 배당 선언 목록조회, 배당 집행 결과 조회

## 📌 Summary
<!-- PR 요약을 써주세요. -->
### 관리자용 배당 API
- 배당 선언 생성 및 수정
- 배당 선언 목록 조회
- 배당 집행 결과 조회

### Admin 인증
- JWT의 subject → userId → user_made_id == "admin"으로 체크

## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
### 1. 폴더구조
```
src/main/java/com/masterpiece/IPiece
 ├─ admin
 │   └─ dividend
 │      ├─ api
 │      │   ├─ AdminDividendController.java
 │      │   └─ dto
 │      │       ├─ request
 │      │       │   └─ AdminUpsertDividendRequest.java
 │      │       └─ response
 │      │           ├─ AdminDividendResponse.java
 │      │           ├─ AdminDividendListResponse.java
 │      │           └─ AdminDividendPayoutsResponse.java
 │      └─ application
 │          └─ AdminDividendService.java
 └─ dividends
     ├─ api
     │   └─ DividendController.java           // 기존 유저용 배당 조회 API (참고용)
     ├─ domain
     │   ├─ Dividends.java
     │   ├─ DividendPayouts.java
     │   └─ DividendStatus.java
     └─ infra
         ├─ DividendsRepository.java
         └─ DividendPayoutsRepository.java
```

### 2. 파일별 역할
#### 2-1. AdminDividendController
- 관리자 전용 배당 관리 REST 컨트롤러
- 공통 로직
  - isAdmin(Authentication)
  - authentication.getName() → userId(Long)
  - UserRepository.findById(userId) → user_made_id == "admin" 인지 검사 
  - 실패 시 403 반환

- 노출 API
  - POST /v1/admin/dividends → 배당 선언 생성/수정
  - GET /v1/admin/dividends → 배당 선언 목록 조회 (필터: productId, status)
  - GET /v1/admin/dividends/{dividendId}/payouts → 배당 집행 결과/요약 조회

#### 2-2. AdminUpsertDividendRequest
- 배당 선언 생성/수정 요청 DTO
- 필드
  - dividendId (nullable)
  - productId 
  - recordDate (ISO-8601 문자열)
  - payoutDate (ISO-8601 문자열)
  - totalAmount 
  
#### 2-3. AdminDividendResponse
- 배당 선언 단건 응답 DTO
- 필드
  - dividend_id
  - product_id
  - status (SCHEDULED/COMPLETED/FAILED)
  - record_date
  - payout_date
  - total_amount

#### 2-4. AdminDividendListResponse
- 배당 선언 목록 응답 DTO
- 필드
  - items: List<AdminDividendResponse>
  - total_count: 전체 개수 
 
#### 2-5. AdminDividendPayoutsResponse
- 특정 배당의 집행 결과(라인 레벨) 응답 DTO
- 필드
  - dividend_id
  - recipient_count : 응답에 포함된 payout 건수
  - total_paid : payout_status == "PAID" 의 합계
  - failed_count : payout_status == "FAILED" 건수
  - items: List<PayoutItem>
    - payout_id
    - account_id
    - payout_amount
    - payout_status ("PAID" / "FAILED")
    - payout_date
 
#### 2-6. AdminDividendService
- 배당 관리자 비즈니스 로직
- 메서드
  - upsertDividend(AdminUpsertDividendRequest request)
    - Dividends 생성/수정
  - listDividends
    - 배당 선언 목록 조회 (필터)
  - getDividendPayouts(Long dividendId, String status)
    - 배당 집행 결과 집계 및 DTO 변환
 
#### 2-7. DividendsRepository
- Dividends JPA Repository
추가 메서드:
List<Dividends> findAllByProduct_ProductId(Long productId);
List<Dividends> findByStatus(DividendStatus status);
List<Dividends> findByProduct_ProductIdAndStatus(Long productId, DividendStatus status);
List<Dividends> findByStatusAndPayoutDateBefore(DividendStatus status, OffsetDateTime now); 

#### 2-8. DividendPayoutsRepository
- DividendPayouts JPA Repository
- 주요 메서드
  - List<DividendPayouts> findByDividends(Dividends dividends);
  - List<DividendPayouts> findByDividendsAndPayoutStatus(Dividends dividends, String payoutStatus);

### 3. 주요 기능
#### 3-1. 배당 선언 생성 및 수정
“어느 상품에, 언제 기준으로, 얼마를 배당할지”를 한 건의 배당 계획으로 등록/수정하는 API.
- 입력
  - product_id : 배당할 상품 ID
  - record_date : 배당 기준일 (스냅샷 날짜/시각)
  - payout_date : 실제 지급 예정일
  - total_amount : 전체 배당 총액(원)
  - dividend_id : 수정할 때만 넣는 기존 배당 ID (없으면 새로 생성)

- 동작
  - dividend_id 없으면 → 새 Dividends 행 생성 (상태: SCHEDULED)
  - dividend_id 있으면 → 해당 행을 찾아 record_date / payout_date / total_amount 수정
  - 단, 상태가 SCHEDULED 일 때만 수정 가능 (이미 완료된 배당은 건드리지 않음)
  - 날짜 형식/순서, 금액, 상품 존재 여부를 모두 검증함

- 결과
  - 생성/수정된 배당 한 건의 정보 반환
  - 프론트에서 이 응답 기반으로 “배당 관리 상세 화면”에 바로 반영 가능

#### 3-2. 배당 선언 목록 조회
등록된 배당 선언들을 리스트로 조회하는 API.

- 입력(쿼리 파라미터)
  - productId (선택): 특정 상품의 배당만 보고 싶을 때
  - status (선택): SCHEDULED / COMPLETED / FAILED 

- 동작
  - 아무 파라미터 없으면 → 전체 배당 선언 다 가져옴
  - productId만 있으면 → 그 상품의 배당만
  - status만 있으면 → 해당 상태의 배당만
  - 둘 다 있으면 → 해당 상품 + 해당 상태 조합만
  - 각각을 간단한 조건 조합으로 처리 (Repository 메서드 3~4개)

- 결과
  - items: dividend_id, product_id, status, record_date, payout_date, total_amount 들이 들어 있는 배열
  - total_count: 전체 개수

#### 3-3. 배당 집행 결과 조회
이미 집행된 배당이 실제로 누구에게 얼마씩 지급됐는지를 한 번에 확인하는 API

- 입력
  - Path: dividendId – 어떤 배당 선언에 대한 결과를 보고 싶은지
  - Query (선택): status – PAID / FAILED (개별 지급 상태)

- 동작
  - Dividends 한 건을 조회 (배당 선언 레벨)
  - DividendPayouts 테이블에서 이 배당에 속한 지급 내역들을 전부 가져옴
  - status 파라미터 없으면 → 해당 배당의 모든 지급
  - status=PAID → 성공 지급만
  - status=FAILED → 실패 건만
  - 가져온 리스트를 기반으로 요약을 계산:
  - recipient_count : 지급 레코드 수
  - total_paid : payout_status == "PAID" 인 금액 합
  - failed_count : payout_status == "FAILED" 개수

- 결과
  - 상단 요약
    - dividend_id
    - recipient_count
    - total_paid
    - failed_count
  - 상세 리스트(items)
    - payout_id
    - account_id
    - payout_amount
    - payout_status (PAID / FAILED)
    - payout_date

### 4. 요청 예시
#### 4-1. 배당 선언 생성
- 엔드포인트 및 헤더
```
POST /v1/admin/dividends
Authorization: Bearer {admin_token}
Content-Type: application/json
```
- request
```
{
  "product_id": 5,
  "record_date": "2026-03-15T23:59:59+09:00",
  "payout_date": "2026-03-31T10:00:00+09:00",
  "total_amount": 30000000
```

#### 4-2. 배당 선언 수정
- 엔드포인트 및 헤더
```
POST /v1/admin/dividends
Authorization: Bearer {admin_token}
Content-Type: application/json
```
- request
```
{
  "dividend_id": 8,
  "product_id": 5,
  "record_date": "2026-03-15T23:59:59+09:00",
  "payout_date": "2026-04-01T10:00:00+09:00",
  "total_amount": 35000000
}
```

#### 4-3. 배당 선언 목록 조회
- 엔드포인트 및 헤더
```
GET /v1/admin/dividends
Authorization: Bearer {admin_token}
```
- 필터 예시
  - 특정 상품: GET /v1/admin/dividends?productId=5
  - 상태 필터: GET /v1/admin/dividends?status=SCHEDULED
  - 조합: GET /v1/admin/dividends?productId=5&status=SCHEDULED

#### 4-4. 배당 집행 결과 조회
- 엔드포인트 및 헤더
```
GET /v1/admin/dividends/8/payouts
Authorization: Bearer {admin_token}
```
- 필터 예시
  - GET /v1/admin/dividends/8/payouts?status=PAID
  - GET /v1/admin/dividends/8/payouts?status=FAILED

### 5. 응답 예시
#### 5-1. 배당 선언 생성 및 수정
```
{
  "dividend_id": 8,
  "product_id": 5,
  "status": "SCHEDULED",
  "record_date": "2026-03-15T23:59:59+09:00",
  "payout_date": "2026-04-01T10:00:00+09:00",
  "total_amount": 35000000
}
```

#### 5-2. 배당 선언 목록 조회
```
{
  "items": [
    {
      "dividend_id": 8,
      "product_id": 5,
      "status": "SCHEDULED",
      "record_date": "2026-03-15T23:59:59+09:00",
      "payout_date": "2026-04-01T10:00:00+09:00",
      "total_amount": 35000000
    },
    {
      "dividend_id": 9,
      "product_id": 7,
      "status": "COMPLETED",
      "record_date": "2026-01-10T23:59:59+09:00",
      "payout_date": "2026-01-31T10:00:00+09:00",
      "total_amount": 50000000
    }
  ],
  "total_count": 2
}
```

#### 5-3. 배당 집행 결과 조회(전체)
```
{
  "dividend_id": 8,
  "recipient_count": 3,
  "total_paid": 75000,
  "failed_count": 1,
  "items": [
    {
      "payout_id": 1,
      "account_id": 101,
      "payout_amount": 25000,
      "payout_status": "PAID",
      "payout_date": "2026-03-31T10:00:01+09:00"
    },
    {
      "payout_id": 2,
      "account_id": 102,
      "payout_amount": 50000,
      "payout_status": "PAID",
      "payout_date": "2026-03-31T10:00:01+09:00"
    },
    {
      "payout_id": 3,
      "account_id": 103,
      "payout_amount": 25000,
      "payout_status": "FAILED",
      "payout_date": "2026-03-31T10:00:02+09:00"
    }
  ]
}
```
- close: #98  

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->


## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->
### 1. 배당 생성
<img width="590" alt="배당 생성" src="https://github.com/user-attachments/assets/6fa4f4df-b00e-445b-95c9-262a894bbde0" /><br><br>

### 2. 배당 수정
<img width="622" alt="배당 수정" src="https://github.com/user-attachments/assets/aa579227-a9e5-45ca-8e30-3892953f6ec2" /><br><br>

### 3. 배당 전체 목록 조회
<img width="565" alt="배당 전체 목록 조회" src="https://github.com/user-attachments/assets/b2ddb08c-0840-48e3-a9b0-7afd78223c1b" /><br><br>

### 4. 배당 집행 결과 조회
<img width="561" alt="배당 집행 결과조회" src="https://github.com/user-attachments/assets/a43bec80-d168-4eb9-b047-33fd55a2e142" /><br><br>

### 5. 특정 상품ID로 배당 조회
<img width="566" alt="특정 상품ID로 배당 조회" src="https://github.com/user-attachments/assets/bf948ab1-55b9-4635-b42d-103e47c4550e" />
