### PR TITLE
[#120] 공모 -> 2차거래 DB 전환 로직 구현

### DIFF
--- a/src/main/java/com/masterpiece/IPiece/admin/offeringandtrade/application/AdminProductService.java
+++ b/src/main/java/com/masterpiece/IPiece/admin/offeringandtrade/application/AdminProductService.java
@@ -3,12 +3,17 @@ package com.masterpiece.IPiece.admin.offeringandtrade.application;
 import com.masterpiece.IPiece.admin.offeringandtrade.api.dto.request.AdminCreateProductRequest;
 import com.masterpiece.IPiece.admin.offeringandtrade.api.dto.request.AdminEnableSecondaryTradingRequest;
 import com.masterpiece.IPiece.admin.offeringandtrade.api.dto.response.AdminEnableSecondaryTradingResponse;
+import com.masterpiece.IPiece.common.domain.account.VirtualAccount;
 import com.masterpiece.IPiece.common.domain.infra.ProductRepository;
+import com.masterpiece.IPiece.common.domain.infra.VirtualAccountRepository;
 import com.masterpiece.IPiece.common.domain.product.Product;
 import com.masterpiece.IPiece.common.domain.product.ProductStatus;
 import com.masterpiece.IPiece.common.exception.BusinessException;
 import com.masterpiece.IPiece.common.exception.ErrorCode;
+import com.masterpiece.IPiece.mypage.domain.Holdings;
+import com.masterpiece.IPiece.mypage.infra.HoldingsRepository;
 import com.masterpiece.IPiece.offering.domain.ProductOfferingInfo;
+import com.masterpiece.IPiece.offering.infra.OfferingSubscriptionsRepository;
 import com.masterpiece.IPiece.offering.infra.ProductOfferingInfoRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.OffsetDateTime;
+import java.util.List;
 
 import static org.springframework.http.HttpStatus.CONFLICT;
 
@@ -25,6 +31,9 @@ public class AdminProductService {
 
     private final ProductRepository productRepository;
     private final ProductOfferingInfoRepository productOfferingInfoRepository;
+    private final OfferingSubscriptionsRepository subscriptionsRepository;
+    private final HoldingsRepository holdingsRepository;
+    private final VirtualAccountRepository virtualAccountRepository;
 
     @Transactional
     public void createProductWithOffering(AdminCreateProductRequest request) {
@@ -87,25 +96,51 @@ public class AdminProductService {
             Long productId,
             AdminEnableSecondaryTradingRequest request
     ) {
-        // 1. confirm 검증
         if (Boolean.FALSE.equals(request.getConfirm())) {
-            // confirm이 false면 잘못된 승인 요청
             throw new BusinessException(ErrorCode.INVALID_SECONDARY_TRADING_CONFIRM);
         }
 
-        // 2. 상품 조회
         Product product = productRepository.findById(productId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.PRODUCT_NOT_FOUND));
 
         ProductStatus previousStatus = product.getStatus();
 
-        // 3. 상태 전환 (비즈니스 로직은 Product 안에 캡슐화)
-        product.enableSecondaryTrading(); // 여기서 이미 상태 검증 및 예외 처리
+        product.enableSecondaryTrading(); // 상태 OFFERING → TRADE
 
-        // 4. 승인/적용 시각
+        // 1) 공모 신청 내역 불러오기
+        List<Object[]> results =
+                subscriptionsRepository.sumQuantityByProduct(productId);
+
+        // 2) product_offering_info 조회 (avg price 계산용)
+        ProductOfferingInfo offeringInfo = productOfferingInfoRepository.findByProductId(productId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.OFFERING_INFO_NOT_FOUND));
+
+        Long offeringPrice = offeringInfo.getOfferingPrice();
+
+        // 3) account_id별로 holdings로 이전
+        for (Object[] row : results) {
+            Long accountId = (Long) row[0];
+            Long quantity   = (Long) row[1];
+
+            VirtualAccount account = virtualAccountRepository.findById(accountId)
+                    .orElseThrow(() -> new BusinessException(ErrorCode.VIRTUAL_ACCOUNT_NOT_FOUND));
+
+            Holdings holding = Holdings.builder()
+                    .virtualAccount(account)
+                    .product(product)
+                    .avgBuyPrice(offeringPrice)
+                    .quantity(quantity)
+                    .build();
+
+            holdingsRepository.save(holding);
+        }
+
+        // 4) offering_subscriptions 전체 삭제
+        subscriptionsRepository.deleteAllByProductId(productId);
+
+
         OffsetDateTime enabledAt = OffsetDateTime.now();
 
-        // 5. 응답 DTO 생성
         return AdminEnableSecondaryTradingResponse.builder()
                 .success(true)
                 .productId(product.getProductId())
@@ -114,4 +149,5 @@ public class AdminProductService {
                 .enabledAt(enabledAt)
                 .build();
     }
+
 }

--- a/src/main/java/com/masterpiece/IPiece/admin/offeringandtrade/application/AdminProductService.java
+++ b/src/main/java/com/masterpiece/IPiece/admin/offeringandtrade/application/AdminProductService.java
@@ -125,12 +125,21 @@ public class AdminProductService {
             VirtualAccount account = virtualAccountRepository.findById(accountId)
                     .orElseThrow(() -> new BusinessException(ErrorCode.VIRTUAL_ACCOUNT_NOT_FOUND));
 
-            Holdings holding = Holdings.builder()
-                    .virtualAccount(account)
-                    .product(product)
-                    .avgBuyPrice(offeringPrice)
-                    .quantity(quantity)
-                    .build();
+            Holdings holding = holdingsRepository
+                    .findByVirtualAccountAndProduct(account, product)
+                    .orElse(Holdings.builder()
+                            .virtualAccount(account)
+                            .product(product)
+                            .avgBuyPrice(0L)
+                            .quantity(0L)
+                            .build());
+
+            long existingQuantity = holding.getQuantity();
+            long totalQuantity = existingQuantity + quantity;
+            long newAvgPrice = ((holding.getAvgBuyPrice() * existingQuantity) + (offeringPrice * quantity)) / totalQuantity;
+
+            holding.setAvgBuyPrice(newAvgPrice);
+            holding.setQuantity(totalQuantity);
 
             holdingsRepository.save(holding);
         }

--- a/src/main/java/com/masterpiece/IPiece/offering/application/OfferingPurchaseService.java
+++ b/src/main/java/com/masterpiece/IPiece/offering/application/OfferingPurchaseService.java
@@ -109,7 +109,7 @@ public class OfferingPurchaseService {
                 .txType("OFFERING_BUY") //
                 .amountKrw(-totalPrice) // 출금이므로 음수
                 .balanceAfter(account.getBalanceKrw()) // 차감된 잔액
-                .description("공모 구매: " + offeringInfo.getProduct().getProductName())
+                .description(offeringInfo.getProduct().getProductName() + " 공모 구매")
                 .numberOfToken(quantity)
                 .build();
 

--- a/src/main/java/com/masterpiece/IPiece/offering/application/OfferingService.java
+++ b/src/main/java/com/masterpiece/IPiece/offering/application/OfferingService.java
@@ -87,7 +87,7 @@ public class OfferingService {
         // 공모 정보 배치 조회
         // 배치 조회란??? 상품마다 공모정보를 조회하는게 아니라 상품Id들을 한번에 조회하는 방식!
         List<ProductOfferingInfo> offeringInfos = productOfferingInfoRepository
-                .findByProductIdIn(productIds);
+                .findAllOfferingProducts();
 
 
         Map<Long, ProductOfferingInfo> offeringInfoMap = offeringInfos.stream()

--- a/src/main/java/com/masterpiece/IPiece/offering/infra/OfferingSubscriptionsRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/offering/infra/OfferingSubscriptionsRepository.java
@@ -3,12 +3,22 @@ package com.masterpiece.IPiece.offering.infra;
 import com.masterpiece.IPiece.mypage.api.dto.response.OfferingAssetDto;
 import com.masterpiece.IPiece.offering.domain.OfferingSubscriptions;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
 public interface OfferingSubscriptionsRepository extends JpaRepository<OfferingSubscriptions, Long> {
+
+    @Query("""
+    SELECT os.virtualAccount.accountId, SUM(os.appliedQuantity)
+    FROM OfferingSubscriptions os
+    WHERE os.productOfferingInfo.productId = :productId
+    GROUP BY os.virtualAccount.accountId
+    """)
+    List<Object[]> sumQuantityByProduct(@Param("productId") Long productId);
+
 
     @Query("""
         SELECT COALESCE(SUM(s.appliedQuantity), 0)
@@ -24,8 +34,8 @@ public interface OfferingSubscriptionsRepository extends JpaRepository<OfferingS
         p.tokenName,
         p.thumbnailImg,
         SUM(os.appliedQuantity),
-        poi.offeringPrice,
         SUM(os.appliedAmountKrw),
+        poi.offeringPrice,
         poi.progressRate,
         poi.offeringStartDate,
         poi.offeringEndDate
@@ -35,6 +45,7 @@ public interface OfferingSubscriptionsRepository extends JpaRepository<OfferingS
     JOIN os.productOfferingInfo poi
     JOIN poi.product p
     WHERE va.accountId = :accountId
+      AND p.status = 'OFFERING'
     GROUP BY 
         p.productId,
         p.productName,
@@ -47,5 +58,10 @@ public interface OfferingSubscriptionsRepository extends JpaRepository<OfferingS
     ORDER BY p.productId DESC
 """)
     List<OfferingAssetDto> findOfferingAssetsByAccountId(@Param("accountId") Long accountId);
+
+
+    @Modifying
+    @Query("DELETE FROM OfferingSubscriptions os WHERE os.productOfferingInfo.productId = :productId")
+    void deleteAllByProductId(@Param("productId") Long productId);
 
 }

--- a/src/main/java/com/masterpiece/IPiece/offering/infra/ProductOfferingInfoRepository.java
+++ b/src/main/java/com/masterpiece/IPiece/offering/infra/ProductOfferingInfoRepository.java
@@ -15,32 +15,47 @@ public interface ProductOfferingInfoRepository extends JpaRepository<ProductOffe
 
     List<ProductOfferingInfo> findByProductIdIn(List<Long> productIds);
 
+    @Query("""
+    SELECT o
+    FROM ProductOfferingInfo o
+    JOIN o.product p
+    WHERE p.status = 'OFFERING'
+    """)
+    List<ProductOfferingInfo> findAllOfferingProducts();
+
 
     @Query("""
-        SELECT COUNT(o)
-        FROM ProductOfferingInfo o
-        WHERE o.offeringStartDate > :now
-        AND o.progressRate != 100
+    SELECT COUNT(o)
+    FROM ProductOfferingInfo o
+    JOIN o.product p
+    WHERE p.status = 'OFFERING'
+      AND o.offeringStartDate > :now
+      AND o.progressRate != 100
     """)
     Long countUpcoming(@Param("now") OffsetDateTime now);
 
     @Query("""
-        SELECT COUNT(o)
-        FROM ProductOfferingInfo o
-        WHERE o.offeringStartDate <= :now
-        AND o.offeringEndDate >= :now
-        AND o.progressRate != 100
+    SELECT COUNT(o)
+    FROM ProductOfferingInfo o
+    JOIN o.product p
+    WHERE p.status = 'OFFERING'
+      AND o.offeringStartDate <= :now
+      AND o.offeringEndDate >= :now
+      AND o.progressRate != 100
     """)
     Long countOngoing(@Param("now") OffsetDateTime now);
 
 
+
     @Query("""
-        SELECT COUNT(o)
-        FROM ProductOfferingInfo o
-        WHERE o.offeringEndDate < :now
-        OR o.progressRate = 100
+    SELECT COUNT(o)
+    FROM ProductOfferingInfo o
+    JOIN o.product p
+    WHERE p.status = 'OFFERING'
+      AND (o.offeringEndDate < :now OR o.progressRate = 100)
     """)
     Long countClosedOrSoldOut(@Param("now") OffsetDateTime now);
+
 
 
 


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
공모 -> 2차거래 DB 전환 로직 구현 


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
공모 상품이 2차거래로 전환될 때 DB 상태가 자연스럽게 분리되도록 수정했습니다.
Product.status가 OFFERING → TRADE 로 변경되면 해당 상품은 공모 API에서 자동으로 제외되며,
공모 신청 데이터는 holdings 로 이관할 수 있도록 구조를 분리했습니다.
- close: #120 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- 공모 종료 후 2차거래로 넘어가는 순간 공모 데이터가 API 결과에 섞이지 않도록 status 기준으로 완전 분리했습니다.
- 이후 공모 신청 이력은 holdings 초기 데이터로 활용할 수 있게 설계했습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->



## 🔥 Test
<!-- Test -->

|   제목   | 화면 캡처 |
| ------- | -------- |
| 전환 전 공모리스트 | <img width="1511" height="866" alt="image" src="https://github.com/user-attachments/assets/a847b17c-3fb6-4d53-9e1d-655cd3e1778b" /> <img width="883" height="173" alt="image" src="https://github.com/user-attachments/assets/6b299333-f20e-4b5f-aead-f7a02f549b10" /> |
| 전환 전 마이페이지 | <img width="1358" height="268" alt="image" src="https://github.com/user-attachments/assets/6b5e8fb5-765d-4c6a-8884-4c3111f7082d" /> |
| 공모 -> 2차 거래 `v1/admin/products/{product_id}/enable-offering` | <img width="711" height="332" alt="image" src="https://github.com/user-attachments/assets/d42e9ef2-74ca-49b6-8091-dae68d3ee54c" /> |
| 전환 후 거래리스트 | <img width="1471" height="637" alt="image" src="https://github.com/user-attachments/assets/f24999ad-84db-4d27-8d7e-5b5d78ff4a00" /> <img width="931" height="182" alt="image" src="https://github.com/user-attachments/assets/3d9e971f-b829-436e-a6fc-d21d2f07ed1c" /> |
| 전환 후 마이페이지 | <img width="1408" height="240" alt="image" src="https://github.com/user-attachments/assets/2f5901f2-b250-4812-bad3-5ff7ddc67baa" /> |


