### PR TITLE
[#126] fix: 블록체인 api swagger 검증테스트 이슈에 대한 수정

### DIFF
--- a/src/main/java/com/masterpiece/IPiece/blockchain/api/controller/AdminBlockchainController.java
+++ b/src/main/java/com/masterpiece/IPiece/blockchain/api/controller/AdminBlockchainController.java
@@ -6,6 +6,7 @@ import com.masterpiece.IPiece.blockchain.application.BlockchainService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import lombok.RequiredArgsConstructor;
+import org.springdoc.core.annotations.ParameterObject;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
@@ -28,6 +29,7 @@ public class AdminBlockchainController {
     @PreAuthorize("hasRole('ADMIN')")
     @Operation(summary = "블록체인 토큰 목록 조회", security = @SecurityRequirement(name = "JWT"))
     public ResponseEntity<TokenListResponse> getTokenList(
+            @ParameterObject
             @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable) {
         TokenListResponse response = blockchainService.getTokenList(pageable);
         return ResponseEntity.ok(response);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -58,6 +58,9 @@ besu:
   rpc-url: ${BESU_RPC_URL}
 admin:
   private-key: ${ADMIN_PRIVATE_KEY}
+blockchain:
+  admin:
+    user-id: 19
 
 springdoc:
   override-with-generic-response: false


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
블록체인 API Swagger 검증 및 실행 관련 이슈 진단 및 일부 해결


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- `develop` 브랜치에서 애플리케이션 실행 시 `blockchain.admin.user-id` 플레이스홀더를 찾지 못해 `BeanCreationException`이 발생하던 문제를 해결했습니다
- 관리자용 블록체인 토큰 목록 조회 API (`GET /v1/admin/blockchain/tokens`) 호출 시 `401 Unauthorized`가 아닌 `500 Internal Server Error`가 발생하던
      문제를 진단했습니다. 이는 `Pageable` 파라미터의 `sort` 값이 Swagger UI에서 `"[string]"`으로 잘못 전달되어 `PropertyReferenceException`이 발생한 것이
      원인입니다.
- `CustomUserDetailsService` 로직 및 JWT 토큰 디코딩 결과, `admin` 계정(`userId=19`, `userMadeId="admin"`)에 `ROLE_ADMIN` 권한이 정상적으로 부여되는
      것으로 판단됩니다. 따라서 `401 Unauthorized` 문제는 Swagger에서 `Authorization` 헤더 설정 오류 또는 `sort` 파라미터 오류로 인한 `500 Internal Server
      Error`가 우선적으로 해결되어야 할 것으로 보입니다.
- close: 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
- `application.yml`에 `blockchain.admin.user-id` 설정을 추가하여 애플리케이션 초기 구동 문제를 해결했습니다.
- `AdminBlockchainController.java`에 `springdoc` 관련 `@ParameterObject` 어노테이션이 추가되었으나, 이는 기능 변경이 아닌 문서화 관련 개선사항으로
      판단되어 함께 커밋에 포함했습니다.

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
- `PropertyReferenceException` 관련 Spring Data JPA `Pageable` sort 파라미터 사용법
- JWT 토큰 디코더 (예: jwt.io)를 통한 토큰 내용 확인


## 🔥 Test
<!-- Test -->
- `application.yml` 수정 후 애플리케이션이 정상적으로 실행되는 것을 확인했습니다.
- `GET /v1/admin/blockchain/tokens` API 호출 시 `Authorization` 헤더에 유효한 JWT 토큰을 포함하여 요청했을 때, `401 Unauthorized` 대신 `500 Internal
      Server Error`가 발생하는 것을 확인했습니다.
- `500 Internal Server Error`는 `sort` 파라미터 문제로 인한 `PropertyReferenceException`임을 로그를 통해 확인했습니다. (Swagger에서 `sort` 파라미터를
      `name,asc` 또는 `createdAt,desc`와 같이 유효한 필드명으로 변경하여 재시도 필요)