### PR TITLE
[#196] feat: CloudFront CDN 적용으로 이미지 전송 최적화

### DIFF
--- a/.github/workflows/backend-cicd.yml
+++ b/.github/workflows/backend-cicd.yml
@@ -126,6 +126,7 @@ jobs:
           TOKENFACTORY_CONTRACT_ADDRESS: ${{ secrets.TOKENFACTORY_CONTRACT_ADDRESS }}
           BLOCKCHAIN_ADMIN_ADDRESS: ${{ secrets.BLOCKCHAIN_ADMIN_ADDRESS }}
           BLOCKCHAIN_CHAIN_ID: ${{ secrets.BLOCKCHAIN_CHAIN_ID }}
+          CDN_URL: ${{ secrets.CDN_URL }}
 
 
         run: |
@@ -152,7 +153,8 @@ jobs:
             --from-literal=KRWT_CONTRACT_ADDRESS="$KRWT_CONTRACT_ADDRESS" \
             --from-literal=TOKENFACTORY_CONTRACT_ADDRESS="$TOKENFACTORY_CONTRACT_ADDRESS" \
             --from-literal=BLOCKCHAIN_ADMIN_ADDRESS="$BLOCKCHAIN_ADMIN_ADDRESS" \
-            --from-literal=BLOCKCHAIN_CHAIN_ID="$BLOCKCHAIN_CHAIN_ID" 
+            --from-literal=BLOCKCHAIN_CHAIN_ID="$BLOCKCHAIN_CHAIN_ID" \
+            --from-literal=CDN_URL="$CDN_URL"
           echo "✅ Kubernetes Secret updated successfully."
 
       - name: Setup Kustomize

--- a/src/main/java/com/masterpiece/IPiece/user/infra/LocalStorageService.java
+++ b/src/main/java/com/masterpiece/IPiece/user/infra/LocalStorageService.java
@@ -21,6 +21,13 @@ public class LocalStorageService implements StorageService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
+    //CDN 지원을 위한 설정 추가
+    @Value("${cloud.aws.cdn.url:}")
+    private String cdnUrl;
+
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
     @Override
     public String saveIdCard(MultipartFile file, String userId) {
         try {
@@ -43,7 +50,7 @@ public class LocalStorageService implements StorageService {
             );
 
             uploadToS3(file, key);
-            return amazonS3.getUrl(bucket, key).toString();
+            return getFileUrl(key);  // CDN 또는 S3 URL 반환
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -74,7 +81,7 @@ public class LocalStorageService implements StorageService {
             );
 
             uploadToS3(file, key);
-            return amazonS3.getUrl(bucket, key).toString();
+            return getFileUrl(key);  // CDN 또는 S3 URL 반환
 
         } catch (Exception e) {
             e.printStackTrace();
@@ -90,6 +97,17 @@ public class LocalStorageService implements StorageService {
         try (InputStream in = file.getInputStream()) {
             amazonS3.putObject(bucket, key, in, metadata);
         }
+    }
+
+    /**
+     * CloudFront CDN이 설정되어 있으면 CDN URL을,
+     * 없으면 S3 직접 URL을 반환
+     */
+    private String getFileUrl(String key) {
+        if (cdnUrl != null && !cdnUrl.isEmpty()) {
+            return cdnUrl + "/" + key;
+        }
+        return amazonS3.getUrl(bucket, key).toString();
     }
 
     private String extractExt(String originalName) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -123,6 +123,8 @@ cloud:
       secret-key: ${AWS_SECRET_KEY}
     s3:
       bucket: ipiece-image
+    cdn:
+      url: ${CDN_URL:}
     region:
       static: ap-northeast-2
     stack:


### PR DESCRIPTION
## 📌 Summary
<!-- PR 요약을 써주세요. -->
CloudFront CDN을 도입하여 S3 이미지 전송 속도를 개선하고 확장 가능한 인프라 구축


## ✍️ Description
<!-- PR에 대한 자세한 설명을 써주세요. -->
- S3에 저장된 이미지(신분증, 상품 이미지)를 CloudFront CDN을 통해 전송하도록 변경하여 글로벌 사용자 대상 이미지 로딩 속도를 개선했습니다.
- close: #196 

## 💡 PR Point
<!-- 코드를 작성할 때 고민했던 부분을 적어주세요 -->
1. 환경변수 기반 설정으로 유연성 확보
- CDN URL을 환경변수로 관리하여 개발/운영 환경 분리 가능
- CDN이 없어도 기존 S3 URL로 자동 Fallback되도록 안전장치 구현

2. 기존 코드 최소 변경
- 기존 로직 유지하면서 URL 생성 부분만 추상화
- getFileUrl() 메소드로 CDN/S3 URL 생성 로직 통합

3. 배포 중단 없이 적용 가능
- Rolling Update 방식으로 점진적 배포
- 환경변수가 없어도 정상 작동하도록 설계

## 📚 Reference 
<!-- 참고할 만한 자료가 있다면 링크나 시각 자료를 달아주세요. -->
[AWS CloudFront 공식 문서](https://aws.amazon.com/ko/cloudfront/)
[CloudFront S3 Integration 가이드](https://aws.amazon.com/ko/cloudfront/getting-started/S3/)
CloudFront Distribution URL: https://d17c83y0vaf42t.cloudfront.net
Origin: ipiece-image.s3.ap-northeast-2.amazonaws.com

## 🔥 Test
<!-- Test -->
테스트 방법:
1. 배포 확인

``` 
# 환경변수 확인
kubectl exec -it <pod-name> -n default -- env | grep CDN_URL
```

2. 실제 이미지 URL 확인
- 신분증 업로드 후 API 응답의 이미지 URL 확인
- CloudFront 도메인(d17c83y0vaf42t.cloudfront.net)이 포함되어 있는지 확인
3. 브라우저 네트워크 탭 확인
- 개발자 도구 → Network 탭
- 이미지 요청 URL이 CloudFront 도메인인지 확인
4. Fallback 테스트 (선택)

``` 
# CDN_URL 제거 후 기존 S3 URL로 작동하는지 확인
kubectl delete configmap backend-cdn-config -n default
```

예상 결과:

- 이미지 URL: https://d17c83y0vaf42t.cloudfront.net/id-card/2024/12/user123/idcard_xxx.jpg
- 기존 S3 URL 대신 CloudFront URL 사용
- 이미지 로딩 정상 작동