### PR TITLE
[#145] fix: git 액션마다 고유한 커밋 값 추가

### DIFF
--- a/.github/workflows/backend-cicd.yml
+++ b/.github/workflows/backend-cicd.yml
@@ -3,8 +3,8 @@ name: Backend CI/CD Pipeline
 on:
   push:
     branches:
-      - 'release/**'     # 릴리즈 브랜치
-      - 'develop'        # 개발 브랜치
+      - 'release/**'      # 릴리즈 브랜치
+      - 'develop'         # 개발 브랜치
     # ✅ README(.md) 등 문서만 수정된 커밋은 파이프라인 실행 안 함
     paths-ignore:
       - '**/*.md'
@@ -81,12 +81,13 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      # 🔥 실행마다 유니크한 태그 생성 (short SHA + run_number)
+      # 🔥 [수정됨] 실행(Run) 뿐만 아니라 재시도(Attempt) 횟수까지 포함하여 유니크한 태그 생성
       - name: Generate image tags
         id: image-tag
         run: |
           SHA_SHORT=$(echo "$GITHUB_SHA" | cut -c1-7)
-          RUN_TAG="${SHA_SHORT}-${GITHUB_RUN_NUMBER}"
+          # SHA + RunNumber + RunAttempt(재시도 횟수) 조합
+          RUN_TAG="${SHA_SHORT}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}"
           echo "Using image tag: $RUN_TAG"
           echo "sha=$RUN_TAG" >> $GITHUB_OUTPUT
 
@@ -106,7 +107,7 @@ jobs:
             --tag $ECR_REGISTRY/$ECR_REPOSITORY:latest \
             --push .
 
-      # ▼▼▼ [동일: K8s Secret 동기화] ▼▼▼
+      # ▼▼▼ [K8s Secret 동기화] ▼▼▼
       - name: Update Kubernetes Secret
         env:
           DB_HOST: ${{ secrets.DB_HOST }}
@@ -127,7 +128,6 @@ jobs:
           BLOCKCHAIN_ADMIN_ADDRESS: ${{ secrets.BLOCKCHAIN_ADMIN_ADDRESS }}
           BLOCKCHAIN_CHAIN_ID: ${{ secrets.BLOCKCHAIN_CHAIN_ID }}
           CDN_URL: ${{ secrets.CDN_URL }}
-
 
         run: |
           echo "🔐 Syncing GitHub Secrets to EKS..."
@@ -168,6 +168,7 @@ jobs:
           ECR_REPOSITORY: ${{ env.ECR_REPOSITORY }}
           BRANCH_NAME: ${{ github.ref_name }}
         run: |
+          # 🚨 [중요] 사용자가 요청한 대로 PROD 오버레이를 타겟팅
           OVERLAY="prod"
           echo "🚀 Unified Pipeline: Deploying branch '${BRANCH_NAME}' to PROD environment with image tag '${SHA_TAG}'."
 
@@ -179,23 +180,26 @@ jobs:
 
           git clone -b develop https://github.com/Woori-FISA-Go/ipiece-manifests.git
           
+          # 경로 이동: backend -> overlays -> prod
           cd ipiece-manifests/apps/backend/overlays/$OVERLAY
 
           echo "Before image:"
           grep -i "$ECR_REPOSITORY" kustomization.yaml || true
 
-          # 이미지 태그 갱신
+          # 이미지 태그 갱신 (SHA_TAG가 매번 바뀌므로 파일 내용이 변경됨)
           kustomize edit set image $ECR_REGISTRY/$ECR_REPOSITORY=$ECR_REGISTRY/$ECR_REPOSITORY:$SHA_TAG
 
           echo "After image:"
           grep -i "$ECR_REPOSITORY" kustomization.yaml || true
 
           cd ../../../..
+          
+          # Git Diff 확인 및 커밋
           if git diff --quiet; then
-            echo "⭕ No changes to commit."
+            echo "⭕ No changes to commit. (This implies tag was identical, but re-run logic should prevent this)"
           else
             git add .
-            git commit -m "chore(backend): update image tag to ${SHA_TAG} for ${OVERLAY} (from ${BRANCH_NAME})"
+            git commit -m "chore(backend): update image tag to ${SHA_TAG} for ${OVERLAY} (attempt: ${{ github.run_attempt }})"
             git push origin develop
             echo "✅ Manifest updated and pushed."
           fi


### PR DESCRIPTION
## 📌 변경 배경 (Motivation)
GitHub Actions 파이프라인이 실패하거나 배포를 다시 트리거해야 할 때 `Re-run jobs`를 사용합니다.
하지만 기존 로직은 `Commit SHA`와 `Run Number`만으로 이미지 태그를 생성했기 때문에, 재실행 시에도 **태그가 동일하게 유지되는 문제**가 있었습니다.
이로 인해 Manifest 리포지토리의 `kustomization.yaml` 내용이 바뀌지 않아(`git diff` 없음), **커밋이 스킵되고 ArgoCD 배포가 일어나지 않는 현상**을 수정했습니다.

## 🛠 변경 사항 (Changes)
1. **이미지 태그 생성 로직 변경 (`backend-cicd.yml`)**
   - 기존: `${SHA_SHORT}-${GITHUB_RUN_NUMBER}`
   - **변경:** `${SHA_SHORT}-${GITHUB_RUN_NUMBER}-${GITHUB_RUN_ATTEMPT}`
   - 이제 재시도 횟수(`Attempt`)가 태그에 포함되어, Re-run 시마다 고유한 태그(예: `-1`, `-2`)가 생성됩니다.

2. **Manifest 커밋 메시지 수정**
   - Manifest 리포지토리에 커밋할 때, 어떤 시도(attempt)에 의한 업데이트인지 식별할 수 있도록 메시지 포맷을 변경했습니다.

## ✅ 체크리스트
- [x] 로컬 또는 액션 린트 테스트 통과 확인
- [x] 이미지 태그 생성 변수(`GITHUB_RUN_ATTEMPT`) 적용 확인